### PR TITLE
Improve capture analysis performance and responsiveness

### DIFF
--- a/Build-And-Run.ps1
+++ b/Build-And-Run.ps1
@@ -1,0 +1,216 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]::new($identity)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
+{
+    $arguments = '-NoProfile -ExecutionPolicy Bypass -File "' + $PSCommandPath + '"'
+    $elevatedProcess = Start-Process -FilePath "powershell.exe" -Verb RunAs -ArgumentList $arguments -PassThru
+    $elevatedProcess.WaitForExit()
+    exit $elevatedProcess.ExitCode
+}
+
+$env:MSBUILDDISABLENODEREUSE = "1"
+$env:DOTNET_CLI_USE_MSBUILD_SERVER = "0"
+
+$repositoryRoot = $PSScriptRoot
+$vswherePath = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+$installerPath = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\setup.exe"
+$appProject = Join-Path $repositoryRoot "source\CapFrameX\CapFrameX.csproj"
+$appPath = Join-Path $repositoryRoot "source\CapFrameX\bin\x64\Release\CapFrameX.exe"
+$nugetPath = Join-Path $repositoryRoot "source\CapFrameX.Charts\WpfView\nuget.exe"
+
+function Get-VisualStudioInstances
+{
+    if (-not (Test-Path -LiteralPath $vswherePath))
+    {
+        throw "Visual Studio Installer was not found. Install Visual Studio Build Tools and rerun this command."
+    }
+
+    return @(& $vswherePath -all -products * -format json | ConvertFrom-Json)
+}
+
+function Get-V143BuildInstance
+{
+    foreach ($instance in (Get-VisualStudioInstances | Sort-Object installationVersion -Descending))
+    {
+        $msbuildPath = Join-Path $instance.installationPath "MSBuild\Current\Bin\MSBuild.exe"
+        $toolsRoot = Join-Path $instance.installationPath "VC\Tools\MSVC"
+        $v143Targets = Join-Path $instance.installationPath "MSBuild\Microsoft\VC\v170"
+
+        if (-not (Test-Path -LiteralPath $msbuildPath) -or
+            -not (Test-Path -LiteralPath $toolsRoot) -or
+            -not (Test-Path -LiteralPath $v143Targets))
+        {
+            continue
+        }
+
+        $toolsets = Get-ChildItem -LiteralPath $toolsRoot -Directory -ErrorAction SilentlyContinue |
+            Where-Object {
+                $version = [Version]$_.Name
+                $version.Major -eq 14 -and $version.Minor -ge 30 -and $version.Minor -lt 50
+            } |
+            Sort-Object { [Version]$_.Name } -Descending
+
+        foreach ($toolset in $toolsets)
+        {
+            $hasCompiler = Test-Path -LiteralPath (Join-Path $toolset.FullName "bin\Hostx64\x64\cl.exe")
+            $hasMfc = Test-Path -LiteralPath (Join-Path $toolset.FullName "atlmfc\include\afx.h")
+            $hasMfcLibraries = Test-Path -LiteralPath (Join-Path $toolset.FullName "atlmfc\lib\x64\mfc140.lib")
+            $hasCli = Test-Path -LiteralPath (Join-Path $toolset.FullName "lib\x64\msvcmrt.lib")
+
+            if ($hasCompiler -and $hasMfc -and $hasMfcLibraries -and $hasCli)
+            {
+                return [PSCustomObject]@{
+                    InstallationPath = $instance.installationPath
+                    InstallationVersion = $instance.installationVersion
+                    MsBuildPath = $msbuildPath
+                    ToolsetVersion = $toolset.Name
+                }
+            }
+        }
+    }
+
+    return $null
+}
+
+function Install-V143Prerequisites
+{
+    if (-not (Test-Path -LiteralPath $installerPath))
+    {
+        throw "Visual Studio Installer was not found at '$installerPath'."
+    }
+
+    $targetInstance = Get-VisualStudioInstances |
+        Where-Object { Test-Path -LiteralPath (Join-Path $_.installationPath "MSBuild\Current\Bin\MSBuild.exe") } |
+        Sort-Object installationVersion -Descending |
+        Select-Object -First 1
+
+    if ($null -eq $targetInstance)
+    {
+        throw "No Visual Studio instance with MSBuild was found."
+    }
+
+    if (Get-Process -Name MSBuild -ErrorAction SilentlyContinue)
+    {
+        throw "MSBuild is currently running. Close Visual Studio/build processes and run this same command again."
+    }
+
+    Write-Host "Installing the v143 x64 compiler, MFC, and C++/CLI prerequisites..." -ForegroundColor Cyan
+    $arguments = 'modify --installPath "' + $targetInstance.installationPath +
+        '" --add Microsoft.VisualStudio.Component.VC.14.44.17.14.x86.x64' +
+        ' --add Microsoft.VisualStudio.Component.VC.14.44.17.14.MFC' +
+        ' --add Microsoft.VisualStudio.Component.VC.14.44.17.14.CLI.Support' +
+        ' --quiet --norestart'
+
+    $installer = Start-Process -FilePath $installerPath -Verb RunAs -ArgumentList $arguments -Wait -PassThru
+    if ($installer.ExitCode -ne 0 -and $installer.ExitCode -ne 3010)
+    {
+        throw "Visual Studio prerequisite installation failed with exit code $($installer.ExitCode)."
+    }
+}
+
+function Invoke-NativeCommand
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "'$FilePath' failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Stop-RunningOutputProcesses
+{
+    $outputDirectory = Split-Path $appPath
+    $ownedExecutablePaths = @(
+        [IO.Path]::GetFullPath($appPath),
+        [IO.Path]::GetFullPath((Join-Path $outputDirectory "PresentMon\PresentMon-2.4.1-x64.exe"))
+    )
+
+    $processes = Get-CimInstance Win32_Process -Filter "Name = 'CapFrameX.exe' OR Name = 'PresentMon-2.4.1-x64.exe'" -ErrorAction SilentlyContinue
+    foreach ($process in $processes)
+    {
+        if ($process.ExecutablePath -and $ownedExecutablePaths -contains [IO.Path]::GetFullPath($process.ExecutablePath))
+        {
+            Stop-Process -Id $process.ProcessId -Force -ErrorAction Stop
+        }
+    }
+}
+
+Push-Location $repositoryRoot
+try
+{
+    $buildInstance = Get-V143BuildInstance
+    if ($null -eq $buildInstance)
+    {
+        Install-V143Prerequisites
+        $buildInstance = Get-V143BuildInstance
+    }
+
+    if ($null -eq $buildInstance)
+    {
+        throw "The v143 compiler, MFC, or C++/CLI support is still unavailable after installation."
+    }
+
+    if (-not (Test-Path -LiteralPath $nugetPath))
+    {
+        throw "The repository NuGet executable was not found at '$nugetPath'."
+    }
+
+    Stop-RunningOutputProcesses
+
+    Write-Host "Using MSVC $($buildInstance.ToolsetVersion) and restoring dependencies..." -ForegroundColor Cyan
+    Invoke-NativeCommand -FilePath $nugetPath -Arguments @(
+        "restore",
+        (Join-Path $repositoryRoot "CapFrameX.sln"),
+        "-NonInteractive",
+        "-Verbosity", "quiet"
+    )
+
+    Invoke-NativeCommand -FilePath "dotnet" -Arguments @(
+        "restore",
+        $appProject,
+        "--runtime", "win-x64",
+        "--property:Platform=x64",
+        "--verbosity", "quiet"
+    )
+
+    Write-Host "Building CapFrameX x64 Release..." -ForegroundColor Cyan
+    Invoke-NativeCommand -FilePath $buildInstance.MsBuildPath -Arguments @(
+        $appProject,
+        "/t:Build",
+        "/p:Configuration=Release",
+        "/p:Platform=x64",
+        "/p:RuntimeIdentifier=win-x64",
+        "/m",
+        "/nr:false",
+        "/nologo",
+        "/v:minimal",
+        "/clp:ErrorsOnly;Summary"
+    )
+
+    if (-not (Test-Path -LiteralPath $appPath))
+    {
+        throw "Build completed but '$appPath' was not produced."
+    }
+
+    $process = Start-Process -FilePath $appPath -WorkingDirectory (Split-Path $appPath) -PassThru
+    Write-Host "CapFrameX is running (PID $($process.Id))." -ForegroundColor Green
+}
+finally
+{
+    & dotnet build-server shutdown *> $null
+    Pop-Location
+}

--- a/source/CapFrameX.Data/FileRecordInfo.cs
+++ b/source/CapFrameX.Data/FileRecordInfo.cs
@@ -7,11 +7,13 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace CapFrameX.Data
 {
-    public class FileRecordInfo : IFileRecordInfo
+	public class FileRecordInfo : IFileRecordInfo
 	{
+		private const int MAX_INDEX_STRING_BYTES = 1024 * 1024;
 		public static string HEADER_MARKER = "//";
 		public static readonly char INFO_SEPERATOR = '=';
 
@@ -58,48 +60,70 @@ namespace CapFrameX.Data
 		public string HAGS { get; private set; }
 		public string PresentationMode { get; private set; }
 		public string Resolution { get; private set; }
+		internal bool UsesProcessListGameName { get; set; }
+
+		private FileRecordInfo()
+		{
+		}
 
 		private FileRecordInfo(FileInfo fileInfo, ISession session)
+			: this(fileInfo, session?.Info, session?.Hash, session?.Runs?.Count ?? 0,
+				session?.Runs?.LastOrDefault()?.CaptureData?.TimeInSeconds?.LastOrDefault() ?? 0)
 		{
-			var creationDateTime = session.Info.CreationDate.ToLocalTime();
+		}
+
+		private FileRecordInfo(FileInfo fileInfo, ISessionInfo sessionInfo, string hash,
+			int runCount, double recordTime)
+		{
+			if (fileInfo == null || sessionInfo == null)
+			{
+				throw new ArgumentException("Record metadata is incomplete.");
+			}
+
+			var creationDateTime = sessionInfo.CreationDate.ToLocalTime();
 			FileInfo = fileInfo;
 			FullPath = fileInfo.FullName;
-			Id = session.Info.Id.ToString();
+			Id = sessionInfo.Id.ToString();
 			CreationDate = creationDateTime.ToString("yyyy-MM-dd");
 			CreationTime = creationDateTime.ToString("HH:mm:ss");
-			ProcessName = session.Info.ProcessName;
-			GameName = session.Info.GameName;
-			ProcessorName = session.Info.Processor;
-			GraphicCardName = session.Info.GPU;
-			SystemRamInfo = session.Info.SystemRam;
-			MotherboardName = session.Info.Motherboard;
-			OsVersion = session.Info.OS;
-			GPUMemoryClock = session.Info.GpuMemoryClock;
-			GPUCoreClock = session.Info.GpuCoreClock;
-			DriverPackage = session.Info.DriverPackage;
-			BaseDriverVersion = session.Info.BaseDriverVersion;
-			GPUDriverVersion = session.Info.GPUDriverVersion;
-			Comment = session.Info.Comment;
-			ProcessName = session.Info.ProcessName;
-			IsAggregated = Convert.ToString(session.Runs.Count() > 1);
+			ProcessName = sessionInfo.ProcessName;
+			GameName = sessionInfo.GameName;
+			ProcessorName = sessionInfo.Processor;
+			GraphicCardName = sessionInfo.GPU;
+			SystemRamInfo = sessionInfo.SystemRam;
+			MotherboardName = sessionInfo.Motherboard;
+			OsVersion = sessionInfo.OS;
+			GPUMemoryClock = sessionInfo.GpuMemoryClock;
+			GPUCoreClock = sessionInfo.GpuCoreClock;
+			DriverPackage = sessionInfo.DriverPackage;
+			BaseDriverVersion = sessionInfo.BaseDriverVersion;
+			GPUDriverVersion = sessionInfo.GPUDriverVersion;
+			Comment = sessionInfo.Comment;
+			IsAggregated = Convert.ToString(runCount > 1);
 			IsValid = true;
-			Hash = session.Hash;
-			ApiInfo = session.Info.ApiInfo;
-			ResizableBar = session.Info.ResizableBar;
-			WinGameMode = session.Info.WinGameMode;
-			HAGS = session.Info.HAGS;
-			PresentationMode = session.Info.PresentationMode;
-			Resolution = session.Info.ResolutionInfo;
+			Hash = hash;
+			RecordTime = recordTime;
+			ApiInfo = sessionInfo.ApiInfo;
+			ResizableBar = sessionInfo.ResizableBar;
+			WinGameMode = sessionInfo.WinGameMode;
+			HAGS = sessionInfo.HAGS;
+			PresentationMode = sessionInfo.PresentationMode;
+			Resolution = sessionInfo.ResolutionInfo;
 		}
 
 		private FileRecordInfo(FileInfo fileInfo, string hash)
+			: this(fileInfo, hash, null)
+		{
+		}
+
+		private FileRecordInfo(FileInfo fileInfo, string hash, string[] lines)
 		{
 			if (fileInfo != null && File.Exists(fileInfo.FullName))
 			{
 				FileInfo = fileInfo;
 				FullPath = fileInfo.FullName;
 				Hash = hash;
-				_lines = File.ReadAllLines(fileInfo.FullName);
+				_lines = lines ?? File.ReadAllLines(fileInfo.FullName);
 
 				if (_lines != null && _lines.Any())
 				{
@@ -373,6 +397,26 @@ namespace CapFrameX.Data
 			return recordInfo;
 		}
 
+		internal static IFileRecordInfo Create(FileInfo fileInfo, string hash, string[] lines)
+		{
+			FileRecordInfo recordInfo = null;
+
+			try
+			{
+				recordInfo = new FileRecordInfo(fileInfo, hash, lines);
+			}
+			catch (ArgumentException)
+			{
+				// Log
+			}
+			catch (Exception)
+			{
+				// Log
+			}
+
+			return recordInfo;
+		}
+
 		public static IFileRecordInfo Create(FileInfo fileInfo, ISession session)
 		{
 			FileRecordInfo recordInfo = null;
@@ -391,6 +435,140 @@ namespace CapFrameX.Data
 			}
 
 			return recordInfo;
+		}
+
+		internal static IFileRecordInfo Create(FileInfo fileInfo, ISessionInfo sessionInfo,
+			string hash, int runCount, double recordTime)
+		{
+			try
+			{
+				return new FileRecordInfo(fileInfo, sessionInfo, hash, runCount, recordTime);
+			}
+			catch (Exception)
+			{
+				return null;
+			}
+		}
+
+		internal void WriteMetadata(BinaryWriter writer)
+		{
+			WriteString(writer, GameName);
+			writer.Write(UsesProcessListGameName);
+			WriteString(writer, ProcessName);
+			WriteString(writer, CreationDate);
+			WriteString(writer, CreationTime);
+			writer.Write(RecordTime);
+			WriteString(writer, CombinedInfo);
+			WriteString(writer, MotherboardName);
+			WriteString(writer, OsVersion);
+			WriteString(writer, ProcessorName);
+			WriteString(writer, SystemRamInfo);
+			WriteString(writer, BaseDriverVersion);
+			WriteString(writer, DriverPackage);
+			WriteString(writer, NumberGPUs);
+			WriteString(writer, GraphicCardName);
+			WriteString(writer, GPUCoreClock);
+			WriteString(writer, GPUMemoryClock);
+			WriteString(writer, GPUMemory);
+			WriteString(writer, GPUDriverVersion);
+			WriteString(writer, Comment);
+			WriteString(writer, IsAggregated);
+			writer.Write(IsValid);
+			writer.Write(HasInfoHeader);
+			WriteString(writer, Id);
+			WriteString(writer, Hash);
+			WriteString(writer, ApiInfo);
+			WriteString(writer, ResizableBar);
+			WriteString(writer, WinGameMode);
+			WriteString(writer, HAGS);
+			WriteString(writer, PresentationMode);
+			WriteString(writer, Resolution);
+		}
+
+		internal static IFileRecordInfo ReadMetadata(FileInfo fileInfo, BinaryReader reader)
+		{
+			if (fileInfo == null)
+			{
+				throw new InvalidDataException("Record metadata path is missing.");
+			}
+
+			var recordInfo = new FileRecordInfo
+			{
+				FileInfo = fileInfo,
+				FullPath = fileInfo.FullName,
+				GameName = ReadString(reader),
+				UsesProcessListGameName = reader.ReadBoolean(),
+				ProcessName = ReadString(reader),
+				CreationDate = ReadString(reader),
+				CreationTime = ReadString(reader),
+				RecordTime = reader.ReadDouble(),
+				CombinedInfo = ReadString(reader),
+				MotherboardName = ReadString(reader),
+				OsVersion = ReadString(reader),
+				ProcessorName = ReadString(reader),
+				SystemRamInfo = ReadString(reader),
+				BaseDriverVersion = ReadString(reader),
+				DriverPackage = ReadString(reader),
+				NumberGPUs = ReadString(reader),
+				GraphicCardName = ReadString(reader),
+				GPUCoreClock = ReadString(reader),
+				GPUMemoryClock = ReadString(reader),
+				GPUMemory = ReadString(reader),
+				GPUDriverVersion = ReadString(reader),
+				Comment = ReadString(reader),
+				IsAggregated = ReadString(reader),
+				IsValid = reader.ReadBoolean(),
+				HasInfoHeader = reader.ReadBoolean(),
+				Id = ReadString(reader),
+				Hash = ReadString(reader),
+				ApiInfo = ReadString(reader),
+				ResizableBar = ReadString(reader),
+				WinGameMode = ReadString(reader),
+				HAGS = ReadString(reader),
+				PresentationMode = ReadString(reader),
+				Resolution = ReadString(reader)
+			};
+
+			return recordInfo;
+		}
+
+		private static void WriteString(BinaryWriter writer, string value)
+		{
+			if (value == null)
+			{
+				writer.Write(-1);
+				return;
+			}
+
+			byte[] bytes = Encoding.UTF8.GetBytes(value);
+			if (bytes.Length > MAX_INDEX_STRING_BYTES)
+			{
+				throw new InvalidDataException("Record metadata string exceeds the index limit.");
+			}
+
+			writer.Write(bytes.Length);
+			writer.Write(bytes);
+		}
+
+		private static string ReadString(BinaryReader reader)
+		{
+			int length = reader.ReadInt32();
+			if (length == -1)
+			{
+				return null;
+			}
+			if (length < 0 || length > MAX_INDEX_STRING_BYTES)
+			{
+				throw new InvalidDataException("Record metadata string length is invalid.");
+			}
+
+			byte[] bytes = reader.ReadBytes(length);
+			if (bytes.Length != length)
+			{
+				throw new EndOfStreamException("Record metadata string is truncated.");
+			}
+
+			return Encoding.UTF8.GetString(bytes);
 		}
 
 		public static bool IsMangoHudFile(string line)

--- a/source/CapFrameX.Data/LocalRecordDataServer.cs
+++ b/source/CapFrameX.Data/LocalRecordDataServer.cs
@@ -12,18 +12,52 @@ namespace CapFrameX.Data
     {
         private double _windowLength;
         private double _currentTime;
+        private ISession _currentSession;
+        private ERemoveOutlierMethod _removeOutlierMethod;
+        private EFilterMode _filterMode;
         private readonly IAppConfiguration _appConfiguration;
+        private readonly object _windowCacheSync = new object();
+        private IList<double> _frametimeWindow;
+        private IList<double> _displayChangeWindow;
+        private IList<double> _gpuActiveWindow;
+        private IList<double> _animationErrorWindow;
+        private IList<Point> _frametimePointWindow;
+        private IList<Point> _gpuActivePointWindow;
+        private IList<Point> _cpuActivePointWindow;
+        private IList<Point> _displayChangePointWindow;
+        private IList<Point> _distributionPointWindow;
+        private IList<double> _fpsWindow;
+        private IList<double> _gpuActiveFpsWindow;
+        private IList<Point> _fpsPointWindow;
+        private IList<Point> _gpuActiveFpsPointWindow;
+        private double? _gpuActiveDeviationPercentage;
+        private bool? _cachedUseDisplayChangeMetrics;
 
         public bool IsActive { get; set; }
 
-        public ISession CurrentSession { get; set; }
+        public ISession CurrentSession
+        {
+            get => _currentSession;
+            set
+            {
+                if (!ReferenceEquals(_currentSession, value))
+                {
+                    _currentSession = value;
+                    InvalidateWindowCache();
+                }
+            }
+        }
 
         public double WindowLength
         {
             get => _windowLength;
             set
             {
-                _windowLength = value;
+                if (_windowLength != value)
+                {
+                    _windowLength = value;
+                    InvalidateWindowCache();
+                }
             }
         }
 
@@ -32,13 +66,39 @@ namespace CapFrameX.Data
             get => _currentTime;
             set
             {
-                _currentTime = value;
+                if (_currentTime != value)
+                {
+                    _currentTime = value;
+                    InvalidateWindowCache();
+                }
             }
         }
 
-        public ERemoveOutlierMethod RemoveOutlierMethod { get; set; }
+        public ERemoveOutlierMethod RemoveOutlierMethod
+        {
+            get => _removeOutlierMethod;
+            set
+            {
+                if (_removeOutlierMethod != value)
+                {
+                    _removeOutlierMethod = value;
+                    InvalidateWindowCache();
+                }
+            }
+        }
 
-        public EFilterMode FilterMode { get; set; }
+        public EFilterMode FilterMode
+        {
+            get => _filterMode;
+            set
+            {
+                if (_filterMode != value)
+                {
+                    _filterMode = value;
+                    InvalidateWindowCache();
+                }
+            }
+        }
 
         public LocalRecordDataServer(IAppConfiguration appConfiguration)
         {
@@ -51,9 +111,16 @@ namespace CapFrameX.Data
             if (CurrentSession == null)
                 return null;
 
-            double startTime = CurrentTime;
-            double endTime = startTime + WindowLength;
-            return CurrentSession.GetFrametimeTimeWindow(startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+            lock (_windowCacheSync)
+            {
+                if (_frametimeWindow == null)
+                {
+                    double startTime = CurrentTime;
+                    _frametimeWindow = CurrentSession.GetFrametimeTimeWindow(
+                        startTime, startTime + WindowLength, _appConfiguration, RemoveOutlierMethod);
+                }
+                return _frametimeWindow;
+            }
         }
 
         public IList<double> GetDisplayChangeTimeWindow()
@@ -61,9 +128,16 @@ namespace CapFrameX.Data
             if (CurrentSession == null)
                 return null;
 
-            double startTime = CurrentTime;
-            double endTime = startTime + WindowLength;
-            return CurrentSession.GetDisplayChangeTimeWindow(startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+            lock (_windowCacheSync)
+            {
+                if (_displayChangeWindow == null)
+                {
+                    double startTime = CurrentTime;
+                    _displayChangeWindow = CurrentSession.GetDisplayChangeTimeWindow(
+                        startTime, startTime + WindowLength, _appConfiguration, RemoveOutlierMethod);
+                }
+                return _displayChangeWindow;
+            }
         }
 
 
@@ -72,9 +146,16 @@ namespace CapFrameX.Data
             if (CurrentSession == null)
                 return null;
 
-            double startTime = CurrentTime;
-            double endTime = startTime + WindowLength;
-            return CurrentSession.GetGpuActiveTimeTimeWindow(startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+            lock (_windowCacheSync)
+            {
+                if (_gpuActiveWindow == null)
+                {
+                    double startTime = CurrentTime;
+                    _gpuActiveWindow = CurrentSession.GetGpuActiveTimeTimeWindow(
+                        startTime, startTime + WindowLength, _appConfiguration, RemoveOutlierMethod);
+                }
+                return _gpuActiveWindow;
+            }
         }
 
         public IList<double> GetAnimationErrorTimeWindow()
@@ -82,9 +163,16 @@ namespace CapFrameX.Data
             if (CurrentSession == null)
                 return null;
 
-            double startTime = CurrentTime;
-            double endTime = startTime + WindowLength;
-            return CurrentSession.GetAnimationErrorTimeWindow(startTime, endTime);
+            lock (_windowCacheSync)
+            {
+                if (_animationErrorWindow == null)
+                {
+                    double startTime = CurrentTime;
+                    _animationErrorWindow = CurrentSession.GetAnimationErrorTimeWindow(
+                        startTime, startTime + WindowLength);
+                }
+                return _animationErrorWindow;
+            }
         }
 
         public IList<Point> GetFrametimePointTimeWindow()
@@ -92,9 +180,16 @@ namespace CapFrameX.Data
             if (CurrentSession == null)
                 return null;
 
-            double startTime = CurrentTime;
-            double endTime = startTime + WindowLength;
-            return CurrentSession.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+            lock (_windowCacheSync)
+            {
+                if (_frametimePointWindow == null)
+                {
+                    double startTime = CurrentTime;
+                    _frametimePointWindow = CurrentSession.GetFrametimePointsTimeWindow(
+                        startTime, startTime + WindowLength, _appConfiguration, RemoveOutlierMethod);
+                }
+                return _frametimePointWindow;
+            }
         }
 
         public IList<Point> GetGpuActiveTimePointTimeWindow()
@@ -102,9 +197,16 @@ namespace CapFrameX.Data
             if (CurrentSession == null)
                 return null;
 
-            double startTime = CurrentTime;
-            double endTime = startTime + WindowLength;
-            return CurrentSession.GetGpuActiveTimePointsTimeWindow(startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+            lock (_windowCacheSync)
+            {
+                if (_gpuActivePointWindow == null)
+                {
+                    double startTime = CurrentTime;
+                    _gpuActivePointWindow = CurrentSession.GetGpuActiveTimePointsTimeWindow(
+                        startTime, startTime + WindowLength, _appConfiguration, RemoveOutlierMethod);
+                }
+                return _gpuActivePointWindow;
+            }
         }
 
         public IList<Point> GetCpuActiveTimePointTimeWindow()
@@ -112,9 +214,16 @@ namespace CapFrameX.Data
             if (CurrentSession == null)
                 return null;
 
-            double startTime = CurrentTime;
-            double endTime = startTime + WindowLength;
-            return CurrentSession.GetCpuActiveTimePointsTimeWindow(startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+            lock (_windowCacheSync)
+            {
+                if (_cpuActivePointWindow == null)
+                {
+                    double startTime = CurrentTime;
+                    _cpuActivePointWindow = CurrentSession.GetCpuActiveTimePointsTimeWindow(
+                        startTime, startTime + WindowLength, _appConfiguration, RemoveOutlierMethod);
+                }
+                return _cpuActivePointWindow;
+            }
         }
 
         public IList<Point> GetFrametimeDistributionPointTimeWindow()
@@ -122,36 +231,107 @@ namespace CapFrameX.Data
             if (CurrentSession == null)
                 return null;
 
-            double startTime = CurrentTime;
-            double endTime = startTime + WindowLength;
-            return CurrentSession.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+            EnsureDisplayMetricCacheIsCurrent();
+            lock (_windowCacheSync)
+            {
+                if (_distributionPointWindow == null)
+                {
+                    double startTime = CurrentTime;
+                    double endTime = startTime + WindowLength;
+                    if (_appConfiguration.UseDisplayChangeMetrics)
+                    {
+                        var displayDistribution = CurrentSession.GetDisplayTimeDistributionPoints(
+                            startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+                        if (displayDistribution.Any())
+                            _distributionPointWindow = displayDistribution;
+                    }
+
+                    if (_distributionPointWindow == null)
+                    {
+                        _distributionPointWindow = CurrentSession.GetFrametimeDistributionPoints(
+                            startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+                    }
+                }
+
+                return _distributionPointWindow;
+            }
         }
 
         public IList<double> GetFpsTimeWindow()
         {
-            if (_appConfiguration.UseDisplayChangeMetrics)
+            EnsureDisplayMetricCacheIsCurrent();
+            lock (_windowCacheSync)
             {
-                return GetDisplayChangeTimeWindow()?.Select(dt => 1000 / dt).ToList();
-            }
-            else
-            {
-                return GetFrametimeTimeWindow()?.Select(ft => 1000 / ft).ToList();
+                if (_fpsWindow == null)
+                {
+                    if (_appConfiguration.UseDisplayChangeMetrics)
+                    {
+                        var displayTimes = GetDisplayChangeTimeWindow();
+                        if (displayTimes != null && displayTimes.Any())
+                            _fpsWindow = displayTimes.Select(time => 1000 / time).ToList();
+                    }
+
+                    if (_fpsWindow == null)
+                        _fpsWindow = GetFrametimeTimeWindow()?.Select(time => 1000 / time).ToList();
+                }
+
+                return _fpsWindow;
             }
         }
 
         public IList<double> GetGpuActiveFpsTimeWindow()
         {
-            return GetGpuActiveTimeTimeWindow()?.Select(ft => 1000 / ft).ToList();
+            lock (_windowCacheSync)
+            {
+                if (_gpuActiveFpsWindow == null)
+                    _gpuActiveFpsWindow = GetGpuActiveTimeTimeWindow()?.Select(ft => 1000 / ft).ToList();
+                return _gpuActiveFpsWindow;
+            }
         }
 
         public IList<Point> GetFpsPointTimeWindow()
         {
-            return GetFrametimePointTimeWindow()?.Select(pnt => new Point(pnt.X, 1000 / pnt.Y)).ToList();
+            if (CurrentSession == null)
+                return null;
+
+            EnsureDisplayMetricCacheIsCurrent();
+            lock (_windowCacheSync)
+            {
+                if (_fpsPointWindow == null)
+                {
+                    IList<Point> timingPoints = null;
+                    if (_appConfiguration.UseDisplayChangeMetrics)
+                    {
+                        if (_displayChangePointWindow == null)
+                        {
+                            _displayChangePointWindow = CurrentSession.GetDisplayChangeTimePointsTimeWindow(
+                                CurrentTime, CurrentTime + WindowLength, _appConfiguration, RemoveOutlierMethod);
+                        }
+                        timingPoints = _displayChangePointWindow;
+                    }
+
+                    if (timingPoints == null || !timingPoints.Any())
+                        timingPoints = GetFrametimePointTimeWindow();
+
+                    _fpsPointWindow = timingPoints?
+                        .Select(point => new Point(point.X, 1000 / point.Y)).ToList();
+                }
+
+                return _fpsPointWindow;
+            }
         }
 
         public IList<Point> GetGpuActiveFpsPointTimeWindow()
         {
-            return GetGpuActiveTimePointTimeWindow()?.Select(pnt => new Point(pnt.X, 1000 / pnt.Y)).ToList();
+            lock (_windowCacheSync)
+            {
+                if (_gpuActiveFpsPointWindow == null)
+                {
+                    _gpuActiveFpsPointWindow = GetGpuActiveTimePointTimeWindow()?
+                        .Select(pnt => new Point(pnt.X, 1000 / pnt.Y)).ToList();
+                }
+                return _gpuActiveFpsPointWindow;
+            }
         }
         public IList<Point> GetDistributionPointTimeWindow()
         {
@@ -163,15 +343,62 @@ namespace CapFrameX.Data
             if (CurrentSession == null)
                 return 0.0;
 
-            double startTime = CurrentTime;
-            double endTime = startTime + WindowLength;
-            return CurrentSession.GetGpuActiveDeviationPercentage(startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+            lock (_windowCacheSync)
+            {
+                if (!_gpuActiveDeviationPercentage.HasValue)
+                {
+                    double startTime = CurrentTime;
+                    double endTime = startTime + WindowLength;
+                    _gpuActiveDeviationPercentage = CurrentSession.GetGpuActiveDeviationPercentage(
+                        startTime, endTime, _appConfiguration, RemoveOutlierMethod);
+                }
+                return _gpuActiveDeviationPercentage.Value;
+            }
         }
 
         public void SetTimeWindow(double currentTime, double windowLength)
         {
-            CurrentTime = currentTime;
-            WindowLength = windowLength;
+            if (_currentTime == currentTime && _windowLength == windowLength)
+                return;
+
+            _currentTime = currentTime;
+            _windowLength = windowLength;
+            InvalidateWindowCache();
+        }
+
+        private void InvalidateWindowCache()
+        {
+            lock (_windowCacheSync)
+            {
+                _frametimeWindow = null;
+                _displayChangeWindow = null;
+                _gpuActiveWindow = null;
+                _animationErrorWindow = null;
+                _frametimePointWindow = null;
+                _gpuActivePointWindow = null;
+                _cpuActivePointWindow = null;
+                _displayChangePointWindow = null;
+                _distributionPointWindow = null;
+                _fpsWindow = null;
+                _gpuActiveFpsWindow = null;
+                _fpsPointWindow = null;
+                _gpuActiveFpsPointWindow = null;
+                _gpuActiveDeviationPercentage = null;
+            }
+        }
+
+        private void EnsureDisplayMetricCacheIsCurrent()
+        {
+            bool useDisplayChangeMetrics = _appConfiguration.UseDisplayChangeMetrics;
+            lock (_windowCacheSync)
+            {
+                if (_cachedUseDisplayChangeMetrics.HasValue
+                    && _cachedUseDisplayChangeMetrics.Value != useDisplayChangeMetrics)
+                {
+                    InvalidateWindowCache();
+                }
+                _cachedUseDisplayChangeMetrics = useDisplayChangeMetrics;
+            }
         }
     }
 }

--- a/source/CapFrameX.Data/RecordManager.cs
+++ b/source/CapFrameX.Data/RecordManager.cs
@@ -3,6 +3,7 @@ using CapFrameX.Contracts.Configuration;
 using CapFrameX.Contracts.Data;
 using CapFrameX.Contracts.RTSS;
 using CapFrameX.Contracts.Sensor;
+using CapFrameX.Configuration;
 using CapFrameX.Data.Session.Classes;
 using CapFrameX.Data.Session.Contracts;
 using CapFrameX.Data.Session.Converters;
@@ -24,7 +25,9 @@ using System.Reactive.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CapFrameX.Data
@@ -41,6 +44,40 @@ namespace CapFrameX.Data
     public class RecordManager : IRecordManager
     {
         private const string IGNOREFLAGMARKER = "//Ignore=true";
+        private const int SESSION_CACHE_CAPACITY = 16;
+        private const int RECORD_INFO_CACHE_CAPACITY = 4096;
+        private const int RECORD_INDEX_MAGIC = 0x58494643; // "CFIX" in little-endian storage
+        private const int RECORD_INDEX_VERSION = 2;
+        private const long RECORD_INDEX_MAX_BYTES = 64L * 1024 * 1024;
+        private const int RECORD_INDEX_WRITE_DELAY_MS = 250;
+        private const string RECORD_INDEX_FILE_NAME = "RecordMetadataIndex.bin";
+
+        private sealed class SessionCacheEntry
+        {
+            public long Length;
+            public long LastWriteTimeUtcTicks;
+            // Session models are mutable. A weak reference avoids extending their lifetime and
+            // lets memory pressure discard large captures while active views can still reuse them.
+            public WeakReference<ISession> Session;
+            public Lazy<ISession> LoadingSession;
+            public long LastAccess;
+        }
+
+        private sealed class RecordInfoCacheEntry
+        {
+            public long Length;
+            public long LastWriteTimeUtcTicks;
+            public IFileRecordInfo RecordInfo;
+            public long LastAccess;
+        }
+
+        private sealed class PersistentRecordInfoEntry
+        {
+            public string Path;
+            public long Length;
+            public long LastWriteTimeUtcTicks;
+            public FileRecordInfo RecordInfo;
+        }
 
         private readonly TimeSpan _fileAccessIntervalTimespan = TimeSpan.FromMilliseconds(200);
         private readonly int _fileAccessIntervalRetryLimit = 50;
@@ -54,6 +91,17 @@ namespace CapFrameX.Data
         private readonly IRTSSService _rTSSService;
         private readonly IEventAggregator _eventAggregator;
         private readonly ICaptureService _captureService;
+        private readonly object _sessionCacheSync = new object();
+        private readonly Dictionary<string, SessionCacheEntry> _sessionCache =
+            new Dictionary<string, SessionCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, RecordInfoCacheEntry> _recordInfoCache =
+            new Dictionary<string, RecordInfoCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        private long _sessionCacheAccessSequence;
+        private long _recordInfoCacheAccessSequence;
+        private bool _recordIndexLoaded;
+        private bool _recordIndexDirty;
+        private bool _recordIndexWriteScheduled;
+        private string _recordIndexPath;
         private PubSubEvent<ViewMessages.UpdateSystemInfo> _updateSystemInfoEvent;
 
         [DllImport("user32.dll", SetLastError = true)]
@@ -137,6 +185,7 @@ namespace CapFrameX.Data
                         lines[commentNameHeaderIndex] = $"{FileRecordInfo.HEADER_MARKER}Comment{FileRecordInfo.INFO_SEPERATOR}{customComment}";
 
                         File.WriteAllLines(recordInfo.FullPath, lines);
+                        InvalidateSessionCache(recordInfo.FullPath);
                     }
                     else
                     {
@@ -163,6 +212,7 @@ namespace CapFrameX.Data
 
                         recordInfo.HasInfoHeader = true;
                         File.WriteAllLines(recordInfo.FullPath, headerLines.Concat(lines));
+                        InvalidateSessionCache(recordInfo.FullPath);
                     }
                 }
             }
@@ -238,15 +288,110 @@ namespace CapFrameX.Data
             {
                 return null;
             }
-            var fileInfo = new FileInfo(path);
-
-            if (!fileInfo.Exists || fileInfo.Length == 0)
-            {
-                return null;
-            }
-
             try
             {
+                var normalizedPath = Path.GetFullPath(path);
+                var fileInfo = new FileInfo(normalizedPath);
+
+                if (!fileInfo.Exists || fileInfo.Length == 0)
+                {
+                    InvalidateSessionCache(normalizedPath);
+                    return null;
+                }
+
+                if (fileInfo.Extension != ".json" && fileInfo.Extension != ".csv")
+                {
+                    return null;
+                }
+
+                long length = fileInfo.Length;
+                long lastWriteTimeUtcTicks = fileInfo.LastWriteTimeUtc.Ticks;
+                SessionCacheEntry cacheEntry;
+                Lazy<ISession> loadingSession;
+
+                lock (_sessionCacheSync)
+                {
+                    if (_sessionCache.TryGetValue(normalizedPath, out cacheEntry)
+                        && cacheEntry.Length == length
+                        && cacheEntry.LastWriteTimeUtcTicks == lastWriteTimeUtcTicks)
+                    {
+                        cacheEntry.LastAccess = ++_sessionCacheAccessSequence;
+                        if (cacheEntry.Session != null
+                            && cacheEntry.Session.TryGetTarget(out var cachedSession))
+                        {
+                            return cachedSession;
+                        }
+
+                        if (cacheEntry.LoadingSession == null)
+                        {
+                            cacheEntry.LoadingSession = CreateSessionLoader(normalizedPath);
+                        }
+                    }
+                    else
+                    {
+                        cacheEntry = new SessionCacheEntry
+                        {
+                            Length = length,
+                            LastWriteTimeUtcTicks = lastWriteTimeUtcTicks,
+                            LastAccess = ++_sessionCacheAccessSequence,
+                            LoadingSession = CreateSessionLoader(normalizedPath)
+                        };
+                        _sessionCache[normalizedPath] = cacheEntry;
+                        TrimSessionCacheLocked(normalizedPath);
+                    }
+
+                    loadingSession = cacheEntry.LoadingSession;
+                }
+
+                ISession loadedSession;
+                try
+                {
+                    // Lazy<T> makes concurrent requests for the same file share one parse.
+                    loadedSession = loadingSession.Value;
+                }
+                catch
+                {
+                    RemoveSessionCacheEntry(normalizedPath, cacheEntry);
+                    throw;
+                }
+
+                fileInfo.Refresh();
+                bool fileUnchanged = fileInfo.Exists
+                    && fileInfo.Length == length
+                    && fileInfo.LastWriteTimeUtc.Ticks == lastWriteTimeUtcTicks;
+
+                lock (_sessionCacheSync)
+                {
+                    if (_sessionCache.TryGetValue(normalizedPath, out var currentEntry)
+                        && ReferenceEquals(currentEntry, cacheEntry))
+                    {
+                        currentEntry.LoadingSession = null;
+                        if (loadedSession != null && fileUnchanged)
+                        {
+                            currentEntry.Session = new WeakReference<ISession>(loadedSession);
+                            currentEntry.LastAccess = ++_sessionCacheAccessSequence;
+                        }
+                        else
+                        {
+                            _sessionCache.Remove(normalizedPath);
+                        }
+                    }
+                }
+
+                return loadedSession;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error while loading {path}", path);
+                return null;
+            }
+        }
+
+        private Lazy<ISession> CreateSessionLoader(string normalizedPath)
+        {
+            return new Lazy<ISession>(() =>
+            {
+                var fileInfo = new FileInfo(normalizedPath);
                 switch (fileInfo.Extension)
                 {
                     case ".json":
@@ -256,11 +401,63 @@ namespace CapFrameX.Data
                     default:
                         return null;
                 }
+            }, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        private void InvalidateSessionCache(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            try
+            {
+                string normalizedPath = Path.GetFullPath(path);
+                bool recordInfoRemoved;
+                lock (_sessionCacheSync)
+                {
+                    _sessionCache.Remove(normalizedPath);
+                    recordInfoRemoved = _recordInfoCache.Remove(normalizedPath);
+                }
+                if (recordInfoRemoved)
+                {
+                    MarkRecordIndexDirty();
+                }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error while loading {path}", path);
-                return null;
+                _logger.LogDebug(ex, "Unable to invalidate cached session for {path}", path);
+            }
+        }
+
+        private void RemoveSessionCacheEntry(string normalizedPath, SessionCacheEntry expectedEntry)
+        {
+            lock (_sessionCacheSync)
+            {
+                if (_sessionCache.TryGetValue(normalizedPath, out var currentEntry)
+                    && ReferenceEquals(currentEntry, expectedEntry))
+                {
+                    _sessionCache.Remove(normalizedPath);
+                }
+            }
+        }
+
+        private void TrimSessionCacheLocked(string preservedPath)
+        {
+            while (_sessionCache.Count > SESSION_CACHE_CAPACITY)
+            {
+                var candidate = _sessionCache
+                    .Where(pair => !string.Equals(pair.Key, preservedPath, StringComparison.OrdinalIgnoreCase))
+                    .OrderBy(pair => pair.Value.LastAccess)
+                    .FirstOrDefault();
+
+                if (candidate.Key == null)
+                {
+                    return;
+                }
+
+                _sessionCache.Remove(candidate.Key);
             }
         }
 
@@ -301,6 +498,13 @@ namespace CapFrameX.Data
 
         private ISession LoadSessionFromCSV(FileInfo csvFile)
         {
+            return LoadSessionFromCSV(csvFile, out _);
+        }
+
+        private ISession LoadSessionFromCSV(FileInfo csvFile, out IFileRecordInfo recordedFileInfo)
+        {
+            recordedFileInfo = null;
+
             // Exception: ignore Nv FrameView summary file
             if (csvFile.Name == "FrameView_Summary.csv")
                 return null;
@@ -309,63 +513,60 @@ namespace CapFrameX.Data
             if (csvFile.Name.Contains("-stats.csv"))
                 return null;
 
-            using (var reader = new StreamReader(csvFile.FullName))
+            var lines = File.ReadAllLines(csvFile.FullName);
+            if (lines.First().Equals(IGNOREFLAGMARKER))
             {
-                var lines = File.ReadAllLines(csvFile.FullName);
-                if (lines.First().Equals(IGNOREFLAGMARKER))
-                {
-                    throw new HasIgnoreFlagException();
-                }
-
-                IEnumerable<string> skippedLines = null;
-
-                // MangoHud capture file
-                if (lines.First().Contains("cpuscheduler") && lines.First().Contains("kernel"))
-                {
-                    skippedLines = lines.Skip(2);
-
-                }
-                // Standard CSV with header
-                else
-                {
-                    skippedLines = lines.SkipWhile(line => line.Contains(FileRecordInfo.HEADER_MARKER));
-
-                    if (FileRecordInfo.IsMangoHudFile(skippedLines.First()))
-                    {
-                        skippedLines = skippedLines.Skip(2);
-                    }
-                }
-
-                var sessionRun = ConvertPresentDataLinesToSessionRun(skippedLines);
-                var recordedFileInfo = FileRecordInfo.Create(csvFile, sessionRun.Hash);
-                var systemInfos = GetSystemInfos(recordedFileInfo);
-
-                return new Session.Classes.Session()
-                {
-                    Hash = string.Join(",", new string[] { sessionRun.Hash }).GetSha1(),
-                    Runs = new List<ISessionRun>() { sessionRun },
-                    Info = new SessionInfo()
-                    {
-                        ProcessName = recordedFileInfo.ProcessName,
-                        Processor = recordedFileInfo.ProcessorName,
-                        GPU = recordedFileInfo.GraphicCardName,
-                        BaseDriverVersion = recordedFileInfo.BaseDriverVersion,
-                        GameName = recordedFileInfo.GameName,
-                        Comment = recordedFileInfo.Comment,
-                        Id = Guid.TryParse(recordedFileInfo.Id, out var guidId) ? guidId : Guid.NewGuid(),
-                        OS = recordedFileInfo.OsVersion,
-                        GpuCoreClock = recordedFileInfo.GPUCoreClock,
-                        GPUCount = recordedFileInfo.NumberGPUs,
-                        SystemRam = recordedFileInfo.SystemRamInfo,
-                        Motherboard = recordedFileInfo.MotherboardName,
-                        DriverPackage = recordedFileInfo.DriverPackage,
-                        GpuMemoryClock = recordedFileInfo.GPUMemoryClock,
-                        CreationDate = DateTime.TryParse(recordedFileInfo.CreationDate + "T" + recordedFileInfo.CreationTime, out var creationDate) ? creationDate : new DateTime(),
-                        AppVersion = new Version(),
-                        ApiInfo = recordedFileInfo.ApiInfo
-                    }
-                };
+                throw new HasIgnoreFlagException();
             }
+
+            IEnumerable<string> skippedLines = null;
+
+            // MangoHud capture file
+            if (lines.First().Contains("cpuscheduler") && lines.First().Contains("kernel"))
+            {
+                skippedLines = lines.Skip(2);
+
+            }
+            // Standard CSV with header
+            else
+            {
+                skippedLines = lines.SkipWhile(line => line.Contains(FileRecordInfo.HEADER_MARKER));
+
+                if (FileRecordInfo.IsMangoHudFile(skippedLines.First()))
+                {
+                    skippedLines = skippedLines.Skip(2);
+                }
+            }
+
+            var sessionRun = ConvertPresentDataLinesToSessionRun(skippedLines);
+            var sessionHash = sessionRun.Hash.GetSha1();
+            recordedFileInfo = FileRecordInfo.Create(csvFile, sessionHash, lines);
+
+            return new Session.Classes.Session()
+            {
+                Hash = sessionHash,
+                Runs = new List<ISessionRun>() { sessionRun },
+                Info = new SessionInfo()
+                {
+                    ProcessName = recordedFileInfo.ProcessName,
+                    Processor = recordedFileInfo.ProcessorName,
+                    GPU = recordedFileInfo.GraphicCardName,
+                    BaseDriverVersion = recordedFileInfo.BaseDriverVersion,
+                    GameName = recordedFileInfo.GameName,
+                    Comment = recordedFileInfo.Comment,
+                    Id = Guid.TryParse(recordedFileInfo.Id, out var guidId) ? guidId : Guid.NewGuid(),
+                    OS = recordedFileInfo.OsVersion,
+                    GpuCoreClock = recordedFileInfo.GPUCoreClock,
+                    GPUCount = recordedFileInfo.NumberGPUs,
+                    SystemRam = recordedFileInfo.SystemRamInfo,
+                    Motherboard = recordedFileInfo.MotherboardName,
+                    DriverPackage = recordedFileInfo.DriverPackage,
+                    GpuMemoryClock = recordedFileInfo.GPUMemoryClock,
+                    CreationDate = DateTime.TryParse(recordedFileInfo.CreationDate + "T" + recordedFileInfo.CreationTime, out var creationDate) ? creationDate : new DateTime(),
+                    AppVersion = new Version(),
+                    ApiInfo = recordedFileInfo.ApiInfo
+                }
+            };
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -373,32 +574,38 @@ namespace CapFrameX.Data
         {
             if (index < array.Length && index > -1)
             {
-                return array[index];
+                return array[index] ?? string.Empty;
             }
             return string.Empty;
         }
 
         public async Task<IFileRecordInfo> GetFileRecordInfo(FileInfo fileInfo)
         {
-            return await Observable.Timer(_fileAccessIntervalTimespan)
+            fileInfo.Refresh();
+            if (TryGetCachedRecordInfo(fileInfo, out var cachedRecordInfo))
+            {
+                return cachedRecordInfo;
+            }
+            long expectedLength = fileInfo.Length;
+            long expectedLastWriteTimeUtcTicks = fileInfo.LastWriteTimeUtc.Ticks;
+
+            var recordInfo = await Observable.Timer(_fileAccessIntervalTimespan)
                 .SelectMany(_ =>
                 {
                     switch (fileInfo.Extension)
                     {
                         case ".csv":
-                            var sessionFromCSV = LoadSessionFromCSV(fileInfo);
+                            var sessionFromCSV = LoadSessionFromCSV(fileInfo, out var recordInfoFromCSV);
 
                             if (sessionFromCSV == null)
                                 return Observable.Empty<IFileRecordInfo>();
 
-                            return Observable.Return(FileRecordInfo.Create(fileInfo, sessionFromCSV.Hash));
+                            return Observable.Return(recordInfoFromCSV);
                         case ".json":
-                            var sessionFromJSON = LoadSessionFromJSON(fileInfo);
-
-                            if (sessionFromJSON == null)
-                                return Observable.Empty<IFileRecordInfo>();
-
-                            return Observable.Return(FileRecordInfo.Create(fileInfo, sessionFromJSON));
+                            var recordInfoFromJSON = LoadRecordInfoFromJSON(fileInfo);
+                            return recordInfoFromJSON == null
+                                ? Observable.Empty<IFileRecordInfo>()
+                                : Observable.Return(recordInfoFromJSON);
                         default:
                             return Observable.Empty<IFileRecordInfo>();
                     }
@@ -419,23 +626,551 @@ namespace CapFrameX.Data
                     }
                 })
                 .Retry(_fileAccessIntervalRetryLimit)
+                .DefaultIfEmpty()
                 .Do(fileRecordInfo =>
                 {
-                    if (fileRecordInfo is IFileRecordInfo)
+                    if (fileRecordInfo != null)
                     {
-                        if (fileRecordInfo.ProcessName == fileRecordInfo.GameName)
-                        {
+                        bool usesProcessListName = fileRecordInfo.ProcessName == fileRecordInfo.GameName
+                            || fileRecordInfo.GameName.IsNullOrEmpty();
+                        if (fileRecordInfo is FileRecordInfo concreteRecordInfo)
+                            concreteRecordInfo.UsesProcessListGameName = usesProcessListName;
+                        if (usesProcessListName)
                             fileRecordInfo.GameName = GetGameNameFromProcessList(fileRecordInfo.ProcessName);
-                        }
-                        else
-                        {
-                            if (fileRecordInfo.GameName.IsNullOrEmpty())
-                            {
-                                fileRecordInfo.GameName = GetGameNameFromProcessList(fileRecordInfo.ProcessName);
-                            }
-                        }
                     }
                 });
+
+            if (recordInfo != null)
+            {
+                StoreRecordInfo(fileInfo, recordInfo, expectedLength, expectedLastWriteTimeUtcTicks);
+            }
+
+            return recordInfo;
+        }
+
+        private IFileRecordInfo LoadRecordInfoFromJSON(FileInfo fileInfo)
+        {
+            using (var stream = new StreamReader(fileInfo.FullName))
+            using (var jsonReader = new JsonTextReader(stream))
+            {
+                var serializer = new JsonSerializer();
+                string hash = null;
+                ISessionInfo sessionInfo = null;
+                int runCount = 0;
+                double recordTime = 0;
+
+                while (jsonReader.Read())
+                {
+                    if (jsonReader.TokenType != JsonToken.PropertyName)
+                    {
+                        continue;
+                    }
+
+                    string propertyName = Convert.ToString(jsonReader.Value, CultureInfo.InvariantCulture);
+                    if (!jsonReader.Read())
+                    {
+                        break;
+                    }
+
+                    if (string.Equals(propertyName, "Hash", StringComparison.OrdinalIgnoreCase))
+                    {
+                        hash = Convert.ToString(jsonReader.Value, CultureInfo.InvariantCulture);
+                    }
+                    else if (string.Equals(propertyName, "Info", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sessionInfo = serializer.Deserialize<SessionInfo>(jsonReader);
+                    }
+                    else if (string.Equals(propertyName, "Runs", StringComparison.OrdinalIgnoreCase)
+                        && jsonReader.TokenType == JsonToken.StartArray)
+                    {
+                        ReadRunMetadata(jsonReader, ref runCount, ref recordTime);
+                    }
+                    else
+                    {
+                        jsonReader.Skip();
+                    }
+                }
+
+                return sessionInfo == null || runCount == 0
+                    ? null
+                    : FileRecordInfo.Create(fileInfo, sessionInfo, hash, runCount, recordTime);
+            }
+        }
+
+        private static void ReadRunMetadata(JsonReader reader, ref int runCount, ref double recordTime)
+        {
+            int arrayDepth = reader.Depth;
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonToken.EndArray && reader.Depth == arrayDepth)
+                {
+                    return;
+                }
+
+                if (reader.TokenType == JsonToken.StartObject && reader.Depth == arrayDepth + 1)
+                {
+                    runCount++;
+                    ReadSingleRunMetadata(reader, ref recordTime);
+                }
+            }
+        }
+
+        private static void ReadSingleRunMetadata(JsonReader reader, ref double recordTime)
+        {
+            int objectDepth = reader.Depth;
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonToken.EndObject && reader.Depth == objectDepth)
+                {
+                    return;
+                }
+
+                if (reader.TokenType != JsonToken.PropertyName)
+                {
+                    continue;
+                }
+
+                string propertyName = Convert.ToString(reader.Value, CultureInfo.InvariantCulture);
+                if (!reader.Read())
+                {
+                    return;
+                }
+
+                if (string.Equals(propertyName, "CaptureData", StringComparison.OrdinalIgnoreCase)
+                    && reader.TokenType == JsonToken.StartObject)
+                {
+                    ReadCaptureRecordTime(reader, ref recordTime);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+        }
+
+        private static void ReadCaptureRecordTime(JsonReader reader, ref double recordTime)
+        {
+            int objectDepth = reader.Depth;
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonToken.EndObject && reader.Depth == objectDepth)
+                {
+                    return;
+                }
+
+                if (reader.TokenType != JsonToken.PropertyName)
+                {
+                    continue;
+                }
+
+                string propertyName = Convert.ToString(reader.Value, CultureInfo.InvariantCulture);
+                if (!reader.Read())
+                {
+                    return;
+                }
+
+                if (string.Equals(propertyName, "TimeInSeconds", StringComparison.OrdinalIgnoreCase)
+                    && reader.TokenType == JsonToken.StartArray)
+                {
+                    int arrayDepth = reader.Depth;
+                    while (reader.Read())
+                    {
+                        if (reader.TokenType == JsonToken.EndArray && reader.Depth == arrayDepth)
+                        {
+                            break;
+                        }
+
+                        if (reader.TokenType == JsonToken.Float || reader.TokenType == JsonToken.Integer)
+                        {
+                            recordTime = Convert.ToDouble(reader.Value, CultureInfo.InvariantCulture);
+                        }
+                    }
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+        }
+
+        private bool TryGetCachedRecordInfo(FileInfo fileInfo, out IFileRecordInfo recordInfo)
+        {
+            EnsureRecordIndexLoaded();
+            recordInfo = null;
+            if (!fileInfo.Exists || fileInfo.Length == 0)
+            {
+                return false;
+            }
+
+            string path = Path.GetFullPath(fileInfo.FullName);
+            bool staleEntryRemoved = false;
+            lock (_sessionCacheSync)
+            {
+                if (_recordInfoCache.TryGetValue(path, out var entry)
+                    && entry.Length == fileInfo.Length
+                    && entry.LastWriteTimeUtcTicks == fileInfo.LastWriteTimeUtc.Ticks)
+                {
+                    entry.LastAccess = ++_recordInfoCacheAccessSequence;
+                    recordInfo = entry.RecordInfo;
+                    if (recordInfo is FileRecordInfo concreteRecordInfo
+                        && concreteRecordInfo.UsesProcessListGameName)
+                    {
+                        recordInfo.GameName = GetGameNameFromProcessList(recordInfo.ProcessName);
+                    }
+                    return recordInfo != null;
+                }
+
+                staleEntryRemoved = _recordInfoCache.Remove(path);
+            }
+            if (staleEntryRemoved)
+            {
+                MarkRecordIndexDirty();
+            }
+            return false;
+        }
+
+        private void StoreRecordInfo(FileInfo fileInfo, IFileRecordInfo recordInfo,
+            long expectedLength, long expectedLastWriteTimeUtcTicks)
+        {
+            fileInfo.Refresh();
+            if (!fileInfo.Exists || fileInfo.Length != expectedLength
+                || fileInfo.LastWriteTimeUtc.Ticks != expectedLastWriteTimeUtcTicks)
+            {
+                return;
+            }
+
+            string path = Path.GetFullPath(fileInfo.FullName);
+            bool persistable = recordInfo is FileRecordInfo;
+            lock (_sessionCacheSync)
+            {
+                _recordInfoCache[path] = new RecordInfoCacheEntry
+                {
+                    Length = fileInfo.Length,
+                    LastWriteTimeUtcTicks = fileInfo.LastWriteTimeUtc.Ticks,
+                    RecordInfo = recordInfo,
+                    LastAccess = ++_recordInfoCacheAccessSequence
+                };
+
+                while (_recordInfoCache.Count > RECORD_INFO_CACHE_CAPACITY)
+                {
+                    var oldest = _recordInfoCache.OrderBy(pair => pair.Value.LastAccess).First();
+                    _recordInfoCache.Remove(oldest.Key);
+                }
+            }
+            if (persistable)
+            {
+                MarkRecordIndexDirty();
+            }
+        }
+
+        private void EnsureRecordIndexLoaded()
+        {
+            lock (_sessionCacheSync)
+            {
+                if (_recordIndexLoaded)
+                {
+                    return;
+                }
+
+                string configFolder = PathServiceProvider.PathService?.ConfigFolder;
+                if (string.IsNullOrWhiteSpace(configFolder))
+                {
+                    return;
+                }
+
+                _recordIndexLoaded = true;
+                _recordIndexPath = Path.Combine(configFolder, "Cache", RECORD_INDEX_FILE_NAME);
+                Dictionary<string, RecordInfoCacheEntry> loadedEntries;
+                try
+                {
+                    loadedEntries = ReadRecordIndex(_recordIndexPath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Ignoring corrupt record metadata index {path}", _recordIndexPath);
+                    TryDeleteRecordIndex(_recordIndexPath);
+                    return;
+                }
+
+                foreach (var pair in loadedEntries)
+                {
+                    if (!_recordInfoCache.ContainsKey(pair.Key))
+                    {
+                        pair.Value.LastAccess = ++_recordInfoCacheAccessSequence;
+                        _recordInfoCache[pair.Key] = pair.Value;
+                    }
+                }
+            }
+        }
+
+        private Dictionary<string, RecordInfoCacheEntry> ReadRecordIndex(string indexPath)
+        {
+            var entries = new Dictionary<string, RecordInfoCacheEntry>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(indexPath) || !File.Exists(indexPath))
+            {
+                return entries;
+            }
+
+            var fileInfo = new FileInfo(indexPath);
+            if (fileInfo.Length <= 0 || fileInfo.Length > RECORD_INDEX_MAX_BYTES)
+            {
+                throw new InvalidDataException("Record metadata index size is invalid.");
+            }
+
+            using (var stream = new FileStream(indexPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = new BinaryReader(stream, Encoding.UTF8))
+            {
+                if (reader.ReadInt32() != RECORD_INDEX_MAGIC)
+                {
+                    throw new InvalidDataException("Record metadata index magic is invalid.");
+                }
+                if (reader.ReadInt32() != RECORD_INDEX_VERSION)
+                {
+                    throw new InvalidDataException("Record metadata index version is unsupported.");
+                }
+
+                int count = reader.ReadInt32();
+                if (count < 0 || count > RECORD_INFO_CACHE_CAPACITY)
+                {
+                    throw new InvalidDataException("Record metadata index entry count is invalid.");
+                }
+
+                for (int index = 0; index < count; index++)
+                {
+                    string path = ReadIndexPath(reader);
+                    long length = reader.ReadInt64();
+                    long lastWriteTimeUtcTicks = reader.ReadInt64();
+                    if (length < 0 || lastWriteTimeUtcTicks < DateTime.MinValue.Ticks
+                        || lastWriteTimeUtcTicks > DateTime.MaxValue.Ticks)
+                    {
+                        throw new InvalidDataException("Record metadata index stamp is invalid.");
+                    }
+
+                    string normalizedPath = Path.GetFullPath(path);
+                    var recordInfo = FileRecordInfo.ReadMetadata(new FileInfo(normalizedPath), reader);
+                    entries[normalizedPath] = new RecordInfoCacheEntry
+                    {
+                        Length = length,
+                        LastWriteTimeUtcTicks = lastWriteTimeUtcTicks,
+                        RecordInfo = recordInfo
+                    };
+                }
+
+                if (stream.Position != stream.Length)
+                {
+                    throw new InvalidDataException("Record metadata index contains trailing data.");
+                }
+            }
+
+            return entries;
+        }
+
+        private static string ReadIndexPath(BinaryReader reader)
+        {
+            int byteCount = reader.ReadInt32();
+            const int MaxPathBytes = 32768;
+            if (byteCount <= 0 || byteCount > MaxPathBytes)
+            {
+                throw new InvalidDataException("Record metadata index path length is invalid.");
+            }
+
+            byte[] bytes = reader.ReadBytes(byteCount);
+            if (bytes.Length != byteCount)
+            {
+                throw new EndOfStreamException("Record metadata index path is truncated.");
+            }
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        private static void WriteIndexPath(BinaryWriter writer, string path)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(path);
+            if (bytes.Length <= 0 || bytes.Length > 32768)
+            {
+                throw new InvalidDataException("Record metadata index path length is invalid.");
+            }
+            writer.Write(bytes.Length);
+            writer.Write(bytes);
+        }
+
+        private void MarkRecordIndexDirty()
+        {
+            lock (_sessionCacheSync)
+            {
+                if (!_recordIndexLoaded || string.IsNullOrWhiteSpace(_recordIndexPath))
+                {
+                    return;
+                }
+
+                _recordIndexDirty = true;
+                if (_recordIndexWriteScheduled)
+                {
+                    return;
+                }
+                _recordIndexWriteScheduled = true;
+            }
+
+            Task.Run((Func<Task>)PersistRecordIndexLoopAsync);
+        }
+
+        private async Task PersistRecordIndexLoopAsync()
+        {
+            int consecutiveFailures = 0;
+            while (true)
+            {
+                await Task.Delay(RECORD_INDEX_WRITE_DELAY_MS).ConfigureAwait(false);
+                List<PersistentRecordInfoEntry> snapshot;
+                string indexPath;
+                lock (_sessionCacheSync)
+                {
+                    if (!_recordIndexDirty)
+                    {
+                        _recordIndexWriteScheduled = false;
+                        return;
+                    }
+
+                    _recordIndexDirty = false;
+                    indexPath = _recordIndexPath;
+                    snapshot = _recordInfoCache
+                        .Where(pair => pair.Value.RecordInfo is FileRecordInfo)
+                        .OrderByDescending(pair => pair.Value.LastAccess)
+                        .Take(RECORD_INFO_CACHE_CAPACITY)
+                        .Select(pair => new PersistentRecordInfoEntry
+                        {
+                            Path = pair.Key,
+                            Length = pair.Value.Length,
+                            LastWriteTimeUtcTicks = pair.Value.LastWriteTimeUtcTicks,
+                            RecordInfo = (FileRecordInfo)pair.Value.RecordInfo
+                        })
+                        .ToList();
+                }
+
+                try
+                {
+                    var persistableSnapshot = snapshot
+                        .Where(CanPersistRecordIndexEntry)
+                        .ToList();
+                    WriteRecordIndexAtomically(indexPath, persistableSnapshot);
+                    consecutiveFailures = 0;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Unable to persist record metadata index {path}", indexPath);
+                    consecutiveFailures++;
+                    if (consecutiveFailures <= 3)
+                    {
+                        lock (_sessionCacheSync)
+                        {
+                            _recordIndexDirty = true;
+                        }
+                    }
+                }
+
+                lock (_sessionCacheSync)
+                {
+                    if (!_recordIndexDirty)
+                    {
+                        _recordIndexWriteScheduled = false;
+                        return;
+                    }
+                }
+            }
+        }
+
+        private bool CanPersistRecordIndexEntry(PersistentRecordInfoEntry entry)
+        {
+            try
+            {
+                using (var writer = new BinaryWriter(Stream.Null, Encoding.UTF8, true))
+                {
+                    WriteIndexPath(writer, entry.Path);
+                    entry.RecordInfo.WriteMetadata(writer);
+                }
+                return true;
+            }
+            catch (InvalidDataException ex)
+            {
+                _logger.LogWarning(ex, "Skipping oversized record metadata index entry {path}", entry.Path);
+                return false;
+            }
+        }
+
+        private static void WriteRecordIndexAtomically(string indexPath, IList<PersistentRecordInfoEntry> entries)
+        {
+            if (string.IsNullOrWhiteSpace(indexPath))
+            {
+                return;
+            }
+
+            string directory = Path.GetDirectoryName(indexPath);
+            Directory.CreateDirectory(directory);
+            string temporaryPath = Path.Combine(directory,
+                Path.GetFileName(indexPath) + "." + Guid.NewGuid().ToString("N") + ".tmp");
+
+            try
+            {
+                using (var stream = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write,
+                    FileShare.None, 4096, FileOptions.WriteThrough))
+                using (var writer = new BinaryWriter(stream, Encoding.UTF8))
+                {
+                    writer.Write(RECORD_INDEX_MAGIC);
+                    writer.Write(RECORD_INDEX_VERSION);
+                    writer.Write(entries.Count);
+                    foreach (var entry in entries)
+                    {
+                        WriteIndexPath(writer, entry.Path);
+                        writer.Write(entry.Length);
+                        writer.Write(entry.LastWriteTimeUtcTicks);
+                        entry.RecordInfo.WriteMetadata(writer);
+                        if (stream.Position > RECORD_INDEX_MAX_BYTES)
+                        {
+                            throw new InvalidDataException("Record metadata index exceeds its size limit.");
+                        }
+                    }
+                    writer.Flush();
+                    stream.Flush(true);
+                }
+
+                if (File.Exists(indexPath))
+                {
+                    // File.Replace is atomic on the supported Windows filesystems. If it fails,
+                    // leave the previous valid index untouched and discard only the temp file.
+                    File.Replace(temporaryPath, indexPath, null, true);
+                }
+                else
+                {
+                    File.Move(temporaryPath, indexPath);
+                }
+            }
+            finally
+            {
+                if (File.Exists(temporaryPath))
+                {
+                    try
+                    {
+                        File.Delete(temporaryPath);
+                    }
+                    catch
+                    {
+                        // A leftover temp file is harmless and never read as the index.
+                    }
+                }
+            }
+        }
+
+        private static void TryDeleteRecordIndex(string indexPath)
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(indexPath) && File.Exists(indexPath))
+                {
+                    File.Delete(indexPath);
+                }
+            }
+            catch
+            {
+                // Corrupt cache data is ignored even if another process currently owns the file.
+            }
         }
 
         public async Task SavePresentmonRawToFile(IEnumerable<string> lines, string process, string recordDirectory = null)
@@ -444,7 +1179,9 @@ namespace CapFrameX.Data
             {
                 var filePath = await GetOutputFilename(process, recordDirectory);
                 lines = new string[] { IGNOREFLAGMARKER, _captureService.ColumnHeader }.Concat(lines);
-                File.WriteAllLines(filePath + ".csv", lines);
+                string outputPath = filePath + ".csv";
+                File.WriteAllLines(outputPath, lines);
+                InvalidateSessionCache(outputPath);
             }
             catch (Exception ex)
             {
@@ -740,6 +1477,9 @@ namespace CapFrameX.Data
                         memoryStream.CopyTo(fileStream);
                     }
 
+                    // Explicit invalidation also covers filesystems where timestamp precision is
+                    // too coarse to distinguish two same-size writes.
+                    InvalidateSessionCache(filePath);
                     _logger.LogInformation("{FilePath} successfully written", filePath);
                 }
                 catch (Exception ex)
@@ -785,7 +1525,7 @@ namespace CapFrameX.Data
             }
 
             var processNameExtStripped = processName.StripExeExtension();
-            return _processList.FindProcessByName(processName)?.DisplayName ?? processNameExtStripped;
+            return _processList?.FindProcessByName(processName)?.DisplayName ?? processNameExtStripped;
         }
 
         private string GetGameNameFromFileDescription(string processName)
@@ -882,11 +1622,11 @@ namespace CapFrameX.Data
                 }
 
                 // Filter lines by dominant process and SwapChainAddress
-                presentLines = FilterByDominantSwapChain(presentLines, headerLine);
+                var dataLines = FilterByDominantSwapChain(presentLines, headerLine);
 
                 var sessionRun = new SessionRun()
                 {
-                    Hash = string.Join(",", presentLines).GetSha1(),
+                    Hash = GetPresentLinesSha1(dataLines),
                     PresentMonRuntime = "unknown"
                 };
 
@@ -898,7 +1638,7 @@ namespace CapFrameX.Data
 
                 string frameStartUnit = "s";
                 var metrics = Array.ConvertAll(headerLine.Split(','), p => p.Trim());
-                for (int i = 0; i < metrics.Count(); i++)
+                for (int i = 0; i < metrics.Length; i++)
                 {
                     if (string.Compare(metrics[i], "AppRenderStart") == 0 || string.Compare(metrics[i], "TimeInSeconds") == 0
                          || string.Compare(metrics[i], "TimeInMs") == 0)
@@ -985,49 +1725,32 @@ namespace CapFrameX.Data
                     }
                 }
 
-                var presentLineCount = presentLines.Count();
-                var captureData = new SessionCaptureData(presentLineCount)
+                var presentLineCount = dataLines.Count;
+                var captureData = new SessionCaptureData(presentLineCount);
+                for (int i = 0; i < captureData.AnimationError.Length; i++)
                 {
-                    AnimationError = Enumerable.Repeat(double.NaN, presentLineCount).ToArray()
-                };
-
-                // When latency data is available initialize array
-                if (indexPcLatency > 0)
-                {
-                    captureData.PcLatency = new double[presentLineCount];
+                    captureData.AnimationError[i] = double.NaN;
                 }
-
-                var dataLines = presentLines.ToArray();
 
                 var presentModeMapping = Enum.GetValues(typeof(EPresentMode)).Cast<EPresentMode>()
                     .ToDictionary(e => e.GetDescription(), e => (int)e);
-                for (int lineIndex = 0; lineIndex < dataLines.Count(); lineIndex++)
+                var requiredColumns = new bool[metrics.Length];
+                MarkRequiredColumns(requiredColumns,
+                    indexFrameStart, indexFrameTimes, indexUntilDisplayedTimes, indexAppMissed,
+                    indexPresentMode, indexMsInPresentAPI, indexDisplayTimes, indexQPCTimes,
+                    indexRuntime, indexAllowsTearing, indexSyncInterval, indexFrameType,
+                    indexPcLatency, indexMsAnimationError, indexmsGPUActive, indexmsCPUActive,
+                    indexCPUStartQPCTime, indexCPUStartQPCTimeInMs);
+                var values = new string[metrics.Length];
+
+                for (int lineIndex = 0; lineIndex < dataLines.Count; lineIndex++)
                 {
                     string line = dataLines[lineIndex];
-                    if (!line.Any())
+                    if (line.Length == 0)
                     {
                         continue;
                     }
-                    var lineCharList = new List<char>();
-                    string[] values = Array.Empty<string>();
-
-                    if (lineIndex == 0)
-                    {
-                        int isInner = -1;
-                        for (int i = 0; i < line.Length; i++)
-                        {
-                            if (line[i] == '"')
-                                isInner *= -1;
-
-                            if (!(line[i] == ',' && isInner == 1))
-                                lineCharList.Add(line[i]);
-
-                        }
-
-                        line = new string(lineCharList.ToArray());
-                    }
-
-                    values = line.Split(',');
+                    ParseCsvFields(line, values, requiredColumns);
                     double frameStart = 0;
 
                     if (lineIndex == 0)
@@ -1182,24 +1905,23 @@ namespace CapFrameX.Data
                 if (indexFrameStart > -1)
                 {
                     var startTime = captureData.TimeInSeconds[0];
-                    captureData.TimeInSeconds = captureData.TimeInSeconds.Select(time => time - startTime).ToArray();
+                    for (int i = 0; i < captureData.TimeInSeconds.Length; i++)
+                    {
+                        captureData.TimeInSeconds[i] -= startTime;
+                    }
                 }
                 // Get render times from frame time data
                 else
                 {
-                    var normalizedTimes = captureData.MsBetweenPresents
-                        .Skip(1)
-                        .Prepend(0)
-                        .ToArray();
-
-                    captureData.TimeInSeconds = normalizedTimes
-                        .Aggregate(new List<double>(), (a, x) =>
+                    double cumulativeTime = 0;
+                    for (int i = 0; i < captureData.TimeInSeconds.Length; i++)
+                    {
+                        if (i > 0)
                         {
-                            a.Add(a.LastOrDefault() + x);
-                            return a;
-                        })
-                        .Select(x => x / 1000d)
-                        .ToArray();
+                            cumulativeTime += captureData.MsBetweenPresents[i];
+                        }
+                        captureData.TimeInSeconds[i] = cumulativeTime / 1000d;
+                    }
                 }
 
                 // Take over sensor data from CSV file
@@ -1220,10 +1942,10 @@ namespace CapFrameX.Data
         /// Filters present data lines to include only the dominant process and its dominant SwapChainAddress.
         /// This handles scenarios where multiple processes or multiple swap chains per process are present.
         /// </summary>
-        private IEnumerable<string> FilterByDominantSwapChain(IEnumerable<string> presentLines, string headerLine)
+        private List<string> FilterByDominantSwapChain(IEnumerable<string> presentLines, string headerLine)
         {
             var linesList = presentLines.ToList();
-            if (!linesList.Any())
+            if (linesList.Count == 0)
                 return linesList;
 
             // Find SwapChainAddress index from header
@@ -1243,57 +1965,79 @@ namespace CapFrameX.Data
             if (swapChainIndex < 0 || processNameIndex < 0)
                 return linesList;
 
-            // Parse all lines to extract (ProcessName, SwapChainAddress) pairs and count occurrences
+            // Extract only the two fields needed here. Splitting every row into every CSV
+            // column doubles most of the parser's allocations before the real parse begins.
             var processSwapChainCounts = new Dictionary<(string ProcessName, string SwapChain), int>();
-            var lineData = new List<(string Line, string ProcessName, string SwapChain)>();
+            var pairOrder = new List<(string ProcessName, string SwapChain)>();
 
             foreach (var line in linesList)
             {
-                var values = line.Split(',');
-                if (values.Length <= Math.Max(swapChainIndex, processNameIndex))
+                if (!TryGetCsvFields(line, processNameIndex, swapChainIndex,
+                    out var processName, out var swapChain))
+                {
                     continue;
+                }
 
-                var processName = values[processNameIndex];
-                var swapChain = values[swapChainIndex];
                 var key = (processName, swapChain);
 
-                if (!processSwapChainCounts.ContainsKey(key))
-                    processSwapChainCounts[key] = 0;
-                processSwapChainCounts[key]++;
-
-                lineData.Add((line, processName, swapChain));
+                if (processSwapChainCounts.TryGetValue(key, out var count))
+                {
+                    processSwapChainCounts[key] = count + 1;
+                }
+                else
+                {
+                    processSwapChainCounts[key] = 1;
+                    pairOrder.Add(key);
+                }
             }
 
-            if (!processSwapChainCounts.Any())
+            if (processSwapChainCounts.Count == 0)
                 return linesList;
 
-            // Group by process and find the dominant SwapChain for each process
-            var processCounts = processSwapChainCounts
-                .GroupBy(kvp => kvp.Key.ProcessName)
-                .ToDictionary(
-                    g => g.Key,
-                    g => new
-                    {
-                        TotalFrames = g.Sum(x => x.Value),
-                        DominantSwapChain = g.OrderByDescending(x => x.Value).First().Key.SwapChain,
-                        DominantSwapChainCount = g.OrderByDescending(x => x.Value).First().Value
-                    });
+            var processOrder = new List<string>();
+            var processTotals = new Dictionary<string, int>();
+            var dominantPairs = new Dictionary<string, (string SwapChain, int Count)>();
+            foreach (var pair in pairOrder)
+            {
+                int count = processSwapChainCounts[pair];
+                if (processTotals.TryGetValue(pair.ProcessName, out var total))
+                {
+                    processTotals[pair.ProcessName] = total + count;
+                }
+                else
+                {
+                    processTotals[pair.ProcessName] = count;
+                    processOrder.Add(pair.ProcessName);
+                }
 
-            // Select the dominant process (the one with the most frames from its dominant SwapChain)
-            var dominantProcess = processCounts
-                .OrderByDescending(p => p.Value.DominantSwapChainCount)
-                .First();
+                if (!dominantPairs.TryGetValue(pair.ProcessName, out var dominant)
+                    || count > dominant.Count)
+                {
+                    dominantPairs[pair.ProcessName] = (pair.SwapChain, count);
+                }
+            }
 
-            var selectedProcessName = dominantProcess.Key;
-            var selectedSwapChain = dominantProcess.Value.DominantSwapChain;
+            string selectedProcessName = processOrder[0];
+            var selectedDominant = dominantPairs[selectedProcessName];
+            foreach (var processName in processOrder.Skip(1))
+            {
+                var candidate = dominantPairs[processName];
+                if (candidate.Count > selectedDominant.Count)
+                {
+                    selectedProcessName = processName;
+                    selectedDominant = candidate;
+                }
+            }
+
+            var selectedSwapChain = selectedDominant.SwapChain;
 
             _logger.LogInformation($"SwapChain filtering: Selected process '{selectedProcessName}' with SwapChain '{selectedSwapChain}' " +
-                $"({dominantProcess.Value.DominantSwapChainCount} frames out of {dominantProcess.Value.TotalFrames} total for this process)");
+                $"({selectedDominant.Count} frames out of {processTotals[selectedProcessName]} total for this process)");
 
             // Log if we're filtering out other processes or swap chains
-            if (processCounts.Count > 1)
+            if (processOrder.Count > 1)
             {
-                _logger.LogInformation($"SwapChain filtering: Filtered out {processCounts.Count - 1} other process(es)");
+                _logger.LogInformation($"SwapChain filtering: Filtered out {processOrder.Count - 1} other process(es)");
             }
 
             var otherSwapChainsForProcess = processSwapChainCounts
@@ -1307,12 +2051,205 @@ namespace CapFrameX.Data
             }
 
             // Filter lines to only include the selected process and SwapChain
-            var filteredLines = lineData
-                .Where(ld => ld.ProcessName == selectedProcessName && ld.SwapChain == selectedSwapChain)
-                .Select(ld => ld.Line)
-                .ToList();
+            var filteredLines = new List<string>(selectedDominant.Count);
+            foreach (var line in linesList)
+            {
+                if (TryGetCsvFields(line, processNameIndex, swapChainIndex,
+                    out var processName, out var swapChain)
+                    && processName == selectedProcessName
+                    && swapChain == selectedSwapChain)
+                {
+                    filteredLines.Add(line);
+                }
+            }
 
             return filteredLines;
+        }
+
+        private static bool TryGetCsvFields(string line, int firstIndex, int secondIndex,
+            out string firstValue, out string secondValue)
+        {
+            firstValue = null;
+            secondValue = null;
+            int highestIndex = Math.Max(firstIndex, secondIndex);
+            int position = 0;
+
+            for (int fieldIndex = 0; fieldIndex <= highestIndex; fieldIndex++)
+            {
+                bool required = fieldIndex == firstIndex || fieldIndex == secondIndex;
+                if (!TryReadCsvField(line, ref position, required, out var value))
+                {
+                    return false;
+                }
+
+                if (fieldIndex == firstIndex)
+                {
+                    firstValue = value;
+                }
+                if (fieldIndex == secondIndex)
+                {
+                    secondValue = value;
+                }
+            }
+
+            return true;
+        }
+
+        private static void MarkRequiredColumns(bool[] requiredColumns, params int[] indices)
+        {
+            foreach (int index in indices)
+            {
+                if (index >= 0 && index < requiredColumns.Length)
+                {
+                    requiredColumns[index] = true;
+                }
+            }
+        }
+
+        private static void ParseCsvFields(string line, string[] values, bool[] requiredColumns)
+        {
+            Array.Clear(values, 0, values.Length);
+            int position = 0;
+            for (int fieldIndex = 0; fieldIndex < values.Length; fieldIndex++)
+            {
+                if (!TryReadCsvField(line, ref position, requiredColumns[fieldIndex], out var value))
+                {
+                    return;
+                }
+
+                if (requiredColumns[fieldIndex])
+                {
+                    values[fieldIndex] = value;
+                }
+            }
+        }
+
+        private static bool TryReadCsvField(string line, ref int position, bool materialize, out string value)
+        {
+            value = null;
+            if (line == null || position > line.Length)
+            {
+                return false;
+            }
+
+            if (position < line.Length && line[position] == '"')
+            {
+                position++;
+                int segmentStart = position;
+                StringBuilder builder = materialize ? new StringBuilder() : null;
+                bool closed = false;
+
+                while (position < line.Length)
+                {
+                    if (line[position] != '"')
+                    {
+                        position++;
+                        continue;
+                    }
+
+                    if (position + 1 < line.Length && line[position + 1] == '"')
+                    {
+                        if (materialize)
+                        {
+                            builder.Append(line, segmentStart, position - segmentStart);
+                            builder.Append('"');
+                        }
+                        position += 2;
+                        segmentStart = position;
+                        continue;
+                    }
+
+                    if (materialize)
+                    {
+                        builder.Append(line, segmentStart, position - segmentStart);
+                    }
+                    position++;
+                    closed = true;
+                    break;
+                }
+
+                if (!closed && materialize)
+                {
+                    builder.Append(line, segmentStart, position - segmentStart);
+                }
+
+                while (position < line.Length && line[position] != ',')
+                {
+                    if (materialize)
+                    {
+                        builder.Append(line[position]);
+                    }
+                    position++;
+                }
+
+                if (materialize)
+                {
+                    value = builder.ToString();
+                }
+            }
+            else
+            {
+                int fieldStart = position;
+                while (position < line.Length && line[position] != ',')
+                {
+                    position++;
+                }
+
+                if (materialize)
+                {
+                    value = line.Substring(fieldStart, position - fieldStart);
+                }
+            }
+
+            if (position < line.Length && line[position] == ',')
+            {
+                position++;
+            }
+            else
+            {
+                position = line.Length + 1;
+            }
+
+            return true;
+        }
+
+        private static string GetPresentLinesSha1(IList<string> lines)
+        {
+            var encoding = Encoding.ASCII;
+            var buffer = new byte[256];
+            var delimiter = new byte[] { (byte)',' };
+
+            using (var sha1 = new SHA1Managed())
+            {
+                for (int i = 0; i < lines.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        sha1.TransformBlock(delimiter, 0, delimiter.Length, delimiter, 0);
+                    }
+
+                    string line = lines[i] ?? string.Empty;
+                    int requiredLength = encoding.GetMaxByteCount(line.Length);
+                    if (buffer.Length < requiredLength)
+                    {
+                        buffer = new byte[requiredLength];
+                    }
+
+                    int byteCount = encoding.GetBytes(line, 0, line.Length, buffer, 0);
+                    if (byteCount > 0)
+                    {
+                        sha1.TransformBlock(buffer, 0, byteCount, buffer, 0);
+                    }
+                }
+
+                sha1.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                var hash = new StringBuilder(sha1.Hash.Length * 2);
+                foreach (byte value in sha1.Hash)
+                {
+                    hash.Append(value.ToString("X2"));
+                }
+                return hash.ToString();
+            }
         }
 
         public void NormalizeStartTimesOfSessionRuns(IEnumerable<ISessionRun> sessionRuns)

--- a/source/CapFrameX.PresentMonInterface/OnlineMetricService.cs
+++ b/source/CapFrameX.PresentMonInterface/OnlineMetricService.cs
@@ -66,6 +66,10 @@ namespace CapFrameX.PresentMonInterface
         // Reusable list buffers to avoid allocations during metric calculations
         private List<double> _reusableListBufferA;
         private List<double> _reusableListBufferB;
+        // Dedicated buffer for the 5-seconds metric path. It runs under
+        // _lock5SecondsMetric, so it must not share a buffer with the
+        // _lockRealtimeMetric readers.
+        private List<double> _reusableListBuffer5Seconds;
 
         // Disposable resources
         private IDisposable _frameDataSubscription;
@@ -101,6 +105,7 @@ namespace CapFrameX.PresentMonInterface
             // Initialize reusable buffers
             _reusableListBufferA = new List<double>(LIST_CAPACITY);
             _reusableListBufferB = new List<double>(LIST_CAPACITY);
+            _reusableListBuffer5Seconds = new List<double>(LIST_CAPACITY);
 
             SubscribeToUpdateSession();
             ConnectOnlineMetricDataStream();
@@ -441,14 +446,19 @@ namespace CapFrameX.PresentMonInterface
             lock (_lockRealtimeMetric)
             {
                 // Use frame times when calculating average fps
-                var buffer = (_appConfiguration.UseDisplayChangeMetrics && metric != EMetric.Average)
+                var useDisplayTimes = _appConfiguration.UseDisplayChangeMetrics && metric != EMetric.Average;
+                var buffer = useDisplayTimes
                     ? _displayedtimesRealtimeSeconds : _frametimesRealtimeSeconds;
 
                 if (buffer == null || buffer.Count == 0)
                     return double.NaN;
 
-                // Reuse list buffer to avoid allocations
-                var samples = buffer.ToList(_reusableListBufferA);
+                var samples = CopyValidTimings(buffer, _reusableListBufferA);
+                if (samples.Count == 0 && useDisplayTimes)
+                    samples = CopyValidTimings(_frametimesRealtimeSeconds, _reusableListBufferA);
+
+                if (samples.Count == 0)
+                    return double.NaN;
 
                 return _frametimeStatisticProvider
                     .GetFpsMetricValue(samples, metric);
@@ -521,23 +531,38 @@ namespace CapFrameX.PresentMonInterface
         {
             lock (_lock5SecondsMetric)
             {
-                var buffer = _appConfiguration.UseDisplayChangeMetrics ? _displaytimes5Seconds : _frametimes5Seconds;
+                var useDisplayTimes = _appConfiguration.UseDisplayChangeMetrics;
+                var buffer = useDisplayTimes ? _displaytimes5Seconds : _frametimes5Seconds;
 
                 if (buffer == null || buffer.Count == 0)
                     return double.NaN;
 
-                // Check for NaN values
-                foreach (var sample in buffer)
-                {
-                    if (double.IsNaN(sample))
-                        return double.NaN;
-                }
+                var samples = CopyValidTimings(buffer, _reusableListBuffer5Seconds);
+                if (samples.Count == 0 && useDisplayTimes)
+                    samples = CopyValidTimings(_frametimes5Seconds, _reusableListBuffer5Seconds);
 
-                var samples = buffer.ToList(_reusableListBufferA);
+                if (samples.Count == 0)
+                    return double.NaN;
 
                 return _frametimeStatisticProvider
                     .GetOnlineStutteringTimePercentage(samples, _appConfiguration.StutteringFactor);
             }
+        }
+
+        private static List<double> CopyValidTimings(IEnumerable<double> source, List<double> target)
+        {
+            target.Clear();
+
+            if (source == null)
+                return target;
+
+            foreach (var timing in source)
+            {
+                if (timing > 0 && !double.IsNaN(timing) && !double.IsInfinity(timing))
+                    target.Add(timing);
+            }
+
+            return target;
         }
 
         public double GetOnlinePcLatencyAverageValue()
@@ -716,6 +741,7 @@ namespace CapFrameX.PresentMonInterface
 
                 _reusableListBufferA?.Clear();
                 _reusableListBufferB?.Clear();
+                _reusableListBuffer5Seconds?.Clear();
             }
 
             _disposed = true;

--- a/source/CapFrameX.Statistics.NetStandard/Contracts/IStatisticProvider.cs
+++ b/source/CapFrameX.Statistics.NetStandard/Contracts/IStatisticProvider.cs
@@ -25,7 +25,11 @@ namespace CapFrameX.Statistics.NetStandard.Contracts
 
         double GetFpsMetricValue(IList<double> sequence, EMetric metric);
 
+        IDictionary<EMetric, double> GetFpsMetricValues(IList<double> sequence, IEnumerable<EMetric> metrics);
+
         double GetFrametimeMetricValue(IList<double> sequence, EMetric metric);
+
+        IDictionary<EMetric, double> GetFrametimeMetricValues(IList<double> sequence, IEnumerable<EMetric> metrics);
 
         double GetPhysicalMetricValue(IList<double> sequence, EMetric metric, double coefficient);
 
@@ -38,6 +42,8 @@ namespace CapFrameX.Statistics.NetStandard.Contracts
         IList<int> GetFpsThresholdCounts(IList<double> frametimes, bool isReversed);
 
         IList<double> GetFpsThresholdTimes(IList<double> frametimes, bool isReversed);
+
+        IList<double> GetVariancePercentages(IList<double> sequence);
 
         IList<double> GetFrametimeVariancePercentages(ISession session);
 

--- a/source/CapFrameX.Statistics.NetStandard/FrametimeStatisticProvider.cs
+++ b/source/CapFrameX.Statistics.NetStandard/FrametimeStatisticProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using CapFrameX.Extensions.NetStandard;
 using CapFrameX.Data.Session.Contracts;
 
@@ -23,6 +24,26 @@ namespace CapFrameX.Statistics.NetStandard
         private static double[] _fpsBuffer;
         [ThreadStatic]
         private static double[] _sortBuffer;
+
+        private sealed class SortedSequenceAnalysis
+        {
+            public double[] Snapshot;
+            public double[] SortedFrametimes;
+            public double[] SortedFps;
+            public double TotalTime;
+        }
+
+        private sealed class SequenceCacheEntry
+        {
+            public readonly object Sync = new object();
+            public SortedSequenceAnalysis Analysis;
+        }
+
+        // The sequence is the weak key, so cached snapshots cannot keep discarded
+        // analysis windows alive. Exact bit comparison invalidates the sorted data
+        // when a mutable list or array changes in place.
+        private static readonly ConditionalWeakTable<IList<double>, SequenceCacheEntry> SequenceAnalysisCache =
+            new ConditionalWeakTable<IList<double>, SequenceCacheEntry>();
 
         public FrametimeStatisticProvider(IFrametimeStatisticProviderOptions options)
         {
@@ -51,6 +72,52 @@ namespace CapFrameX.Statistics.NetStandard
                 _sortBuffer = new double[Math.Max(minSize, 1024)];
             }
             return _sortBuffer;
+        }
+
+        private static SortedSequenceAnalysis GetSortedSequenceAnalysis(IList<double> sequence)
+        {
+            var entry = SequenceAnalysisCache.GetValue(sequence, _ => new SequenceCacheEntry());
+            lock (entry.Sync)
+            {
+                if (entry.Analysis != null && SequenceMatchesSnapshot(sequence, entry.Analysis.Snapshot))
+                    return entry.Analysis;
+
+                var snapshot = sequence.ToArray();
+                var sortedFrametimes = (double[])snapshot.Clone();
+                Array.Sort(sortedFrametimes);
+
+                int count = sortedFrametimes.Length;
+                var sortedFps = new double[count];
+                double totalTime = 0;
+                for (int i = 0; i < count; i++)
+                {
+                    totalTime += sortedFrametimes[i];
+                    sortedFps[i] = 1000.0 / sortedFrametimes[count - i - 1];
+                }
+
+                entry.Analysis = new SortedSequenceAnalysis
+                {
+                    Snapshot = snapshot,
+                    SortedFrametimes = sortedFrametimes,
+                    SortedFps = sortedFps,
+                    TotalTime = totalTime
+                };
+                return entry.Analysis;
+            }
+        }
+
+        private static bool SequenceMatchesSnapshot(IList<double> sequence, double[] snapshot)
+        {
+            if (snapshot == null || sequence.Count != snapshot.Length)
+                return false;
+
+            for (int i = 0; i < snapshot.Length; i++)
+            {
+                if (BitConverter.DoubleToInt64Bits(sequence[i]) != BitConverter.DoubleToInt64Bits(snapshot[i]))
+                    return false;
+            }
+
+            return true;
         }
 
         public double GetAdaptiveStandardDeviation(IList<double> sequence, double timeWindow)
@@ -138,21 +205,50 @@ namespace CapFrameX.Statistics.NetStandard
             {
                 case ERemoveOutlierMethod.DeciPercentile:
                     {
-                        var deciPercentile = sequence.Quantile(TAU);
-                        adjustedSequence = new List<double>();
-
-                        foreach (var element in sequence)
+                        if (sequence.Count < 2 || sequence.All(value => value == sequence[0]))
                         {
-                            if (element < deciPercentile)
+                            adjustedSequence = new List<double>(sequence);
+                            break;
+                        }
+
+                        // Remove exactly the slowest 0.1% of samples while preserving
+                        // capture order. A threshold-only comparison can accidentally
+                        // remove every sample when many frametimes share the cutoff.
+                        // The epsilon compensates the binary representation of (1 - TAU),
+                        // which otherwise yields ceil(1.0000000000000002) = 2 at N = 1000.
+                        int removeCount = Math.Max(1, (int)Math.Ceiling(sequence.Count * (1 - TAU) - 1E-9));
+                        var sortedValues = sequence.ToArray();
+                        Array.Sort(sortedValues);
+                        var removals = new Dictionary<double, int>();
+
+                        for (int i = sortedValues.Length - removeCount; i < sortedValues.Length; i++)
+                        {
+                            int count;
+                            removals.TryGetValue(sortedValues[i], out count);
+                            removals[sortedValues[i]] = count + 1;
+                        }
+
+                        adjustedSequence = new List<double>(sequence.Count - removeCount);
+                        foreach (double element in sequence)
+                        {
+                            int count;
+                            if (removals.TryGetValue(element, out count) && count > 0)
+                            {
+                                removals[element] = count - 1;
+                            }
+                            else
+                            {
                                 adjustedSequence.Add(element);
+                            }
                         }
                     }
                     break;
+                // Not implemented. Return the input unchanged instead of null so
+                // callers that no longer null-coalesce cannot hit an NRE.
                 case ERemoveOutlierMethod.InterquartileRange:
-                    break;
                 case ERemoveOutlierMethod.ThreeSigma:
-                    break;
                 case ERemoveOutlierMethod.TwoDotFiveSigma:
+                    adjustedSequence = sequence;
                     break;
                 case ERemoveOutlierMethod.None:
                     adjustedSequence = sequence;
@@ -347,6 +443,110 @@ namespace CapFrameX.Statistics.NetStandard
             }
         }
 
+        public IDictionary<EMetric, double> GetFpsMetricValues(IList<double> sequence, IEnumerable<EMetric> metrics)
+        {
+            var requestedMetrics = metrics.Distinct().ToArray();
+            var results = new Dictionary<EMetric, double>(requestedMetrics.Length);
+
+            if (sequence == null || sequence.Count == 0)
+            {
+                foreach (var metric in requestedMetrics)
+                {
+                    results[metric] = double.NaN;
+                }
+
+                return results;
+            }
+
+            try
+            {
+                var analysis = GetSortedSequenceAnalysis(sequence);
+                var sortedFrametimes = analysis.SortedFrametimes;
+                var sortedFps = analysis.SortedFps;
+                int count = sortedFrametimes.Length;
+                double totalTime = analysis.TotalTime;
+
+                foreach (var metric in requestedMetrics)
+                {
+                    double metricValue;
+                    switch (metric)
+                    {
+                        case EMetric.Max:
+                            metricValue = sortedFps[count - 1];
+                            break;
+                        case EMetric.P99:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFps, 0.99);
+                            break;
+                        case EMetric.P95:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFps, 0.95);
+                            break;
+                        case EMetric.Average:
+                        case EMetric.GpuActiveAverage:
+                            metricValue = count * 1000 / totalTime;
+                            break;
+                        case EMetric.Median:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFps, 0.5);
+                            break;
+                        case EMetric.P5:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFps, 0.05);
+                            break;
+                        case EMetric.P1:
+                        case EMetric.GpuActiveP1:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFps, 0.01);
+                            break;
+                        case EMetric.P0dot2:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFps, 0.002);
+                            break;
+                        case EMetric.P0dot1:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFps, 0.001);
+                            break;
+                        case EMetric.OnePercentLowAverage:
+                        case EMetric.GpuActiveOnePercentLowAverage:
+                            metricValue = 1000 / GetHighAverageFromSorted(sortedFrametimes, 0.99);
+                            break;
+                        case EMetric.ZerodotTwoPercentLowAverage:
+                            metricValue = 1000 / GetHighAverageFromSorted(sortedFrametimes, 0.998);
+                            break;
+                        case EMetric.ZerodotOnePercentLowAverage:
+                            metricValue = 1000 / GetHighAverageFromSorted(sortedFrametimes, 0.999);
+                            break;
+                        case EMetric.OnePercentLowIntegral:
+                            metricValue = 1000 / GetHighIntegralFromSorted(sortedFrametimes, 0.99, totalTime);
+                            break;
+                        case EMetric.ZerodotTwoPercentLowIntegral:
+                            metricValue = 1000 / GetHighIntegralFromSorted(sortedFrametimes, 0.998, totalTime);
+                            break;
+                        case EMetric.ZerodotOnePercentLowIntegral:
+                            metricValue = 1000 / GetHighIntegralFromSorted(sortedFrametimes, 0.999, totalTime);
+                            break;
+                        case EMetric.Min:
+                            metricValue = sortedFps[0];
+                            break;
+                        case EMetric.AdaptiveStd:
+                            metricValue = GetAdaptiveStandardDeviation(
+                                sequence.Select(value => 1000.0 / value).ToList(),
+                                _options.IntervalAverageWindowTime);
+                            break;
+                        default:
+                            metricValue = double.NaN;
+                            break;
+                    }
+
+                    results[metric] = Math.Round(metricValue, _options.FpsValuesRoundingDigits,
+                        MidpointRounding.AwayFromZero);
+                }
+            }
+            catch (Exception)
+            {
+                foreach (var metric in requestedMetrics)
+                {
+                    results[metric] = double.NaN;
+                }
+            }
+
+            return results;
+        }
+
         /// <summary>
         /// Gets the maximum value from an array segment without allocations.
         /// </summary>
@@ -450,6 +650,140 @@ namespace CapFrameX.Statistics.NetStandard
             }
 
             return Math.Round(metricValue, _options.FpsValuesRoundingDigits, MidpointRounding.AwayFromZero);
+        }
+
+        public IDictionary<EMetric, double> GetFrametimeMetricValues(IList<double> sequence, IEnumerable<EMetric> metrics)
+        {
+            var requestedMetrics = metrics.Distinct().ToArray();
+            var results = new Dictionary<EMetric, double>(requestedMetrics.Length);
+
+            if (sequence == null || sequence.Count == 0)
+            {
+                foreach (var metric in requestedMetrics)
+                {
+                    results[metric] = double.NaN;
+                }
+
+                return results;
+            }
+
+            try
+            {
+                var analysis = GetSortedSequenceAnalysis(sequence);
+                var sortedFrametimes = analysis.SortedFrametimes;
+                double totalTime = analysis.TotalTime;
+                int count = sortedFrametimes.Length;
+
+                foreach (var metric in requestedMetrics)
+                {
+                    double metricValue;
+                    switch (metric)
+                    {
+                        case EMetric.Max:
+                            metricValue = sortedFrametimes[count - 1];
+                            break;
+                        case EMetric.P99:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFrametimes, 0.01);
+                            break;
+                        case EMetric.P95:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFrametimes, 0.05);
+                            break;
+                        case EMetric.Average:
+                        case EMetric.GpuActiveAverage:
+                        case EMetric.CpuActiveAverage:
+                            metricValue = totalTime / count;
+                            break;
+                        case EMetric.Median:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFrametimes, 0.5);
+                            break;
+                        case EMetric.P5:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFrametimes, 0.95);
+                            break;
+                        case EMetric.P1:
+                        case EMetric.GpuActiveP1:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFrametimes, 0.99);
+                            break;
+                        case EMetric.P0dot2:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFrametimes, 0.998);
+                            break;
+                        case EMetric.P0dot1:
+                            metricValue = SortedArrayStatistics.Quantile(sortedFrametimes, 0.999);
+                            break;
+                        case EMetric.OnePercentLowAverage:
+                        case EMetric.GpuActiveOnePercentLowAverage:
+                            metricValue = GetHighAverageFromSorted(sortedFrametimes, 0.99);
+                            break;
+                        case EMetric.ZerodotTwoPercentLowAverage:
+                            metricValue = GetHighAverageFromSorted(sortedFrametimes, 0.998);
+                            break;
+                        case EMetric.ZerodotOnePercentLowAverage:
+                            metricValue = GetHighAverageFromSorted(sortedFrametimes, 0.999);
+                            break;
+                        case EMetric.OnePercentLowIntegral:
+                            metricValue = GetHighIntegralFromSorted(sortedFrametimes, 0.99, totalTime);
+                            break;
+                        case EMetric.ZerodotTwoPercentLowIntegral:
+                            metricValue = GetHighIntegralFromSorted(sortedFrametimes, 0.998, totalTime);
+                            break;
+                        case EMetric.ZerodotOnePercentLowIntegral:
+                            metricValue = GetHighIntegralFromSorted(sortedFrametimes, 0.999, totalTime);
+                            break;
+                        case EMetric.Min:
+                            metricValue = sortedFrametimes[0];
+                            break;
+                        case EMetric.AdaptiveStd:
+                            metricValue = GetAdaptiveStandardDeviation(sequence, _options.IntervalAverageWindowTime);
+                            break;
+                        default:
+                            metricValue = double.NaN;
+                            break;
+                    }
+
+                    results[metric] = Math.Round(metricValue, _options.FpsValuesRoundingDigits,
+                        MidpointRounding.AwayFromZero);
+                }
+            }
+            catch (Exception)
+            {
+                foreach (var metric in requestedMetrics)
+                {
+                    results[metric] = double.NaN;
+                }
+            }
+
+            return results;
+        }
+
+        private static double GetHighAverageFromSorted(double[] sortedFrametimes, double quantile)
+        {
+            double threshold = SortedArrayStatistics.Quantile(sortedFrametimes, quantile);
+            double sum = 0;
+            int count = 0;
+
+            for (int i = sortedFrametimes.Length - 1; i >= 0 && sortedFrametimes[i] >= threshold; i--)
+            {
+                sum += sortedFrametimes[i];
+                count++;
+            }
+
+            return sum / count;
+        }
+
+        private static double GetHighIntegralFromSorted(double[] sortedFrametimes, double quantile, double totalTime)
+        {
+            double targetTime = totalTime * (1 - quantile);
+            double accumulatedTime = 0;
+
+            for (int i = sortedFrametimes.Length - 1; i >= 0; i--)
+            {
+                accumulatedTime += sortedFrametimes[i];
+                if (accumulatedTime >= targetTime)
+                {
+                    return sortedFrametimes[i];
+                }
+            }
+
+            return sortedFrametimes[0];
         }
 
         public double GetPhysicalMetricValue(IList<double> sequence, EMetric metric, double coefficient)
@@ -585,34 +919,42 @@ namespace CapFrameX.Statistics.NetStandard
         public IMetricAnalysis GetMetricAnalysis(IList<double> frametimes, IList<double> displaytimes,
             bool useDisplayChangeMetrics, string secondMetric, string thirdMetric)
         {
-            var average = GetFpsMetricValue(frametimes, EMetric.Average);
+            var secondMetricType = secondMetric.ConvertToEnum<EMetric>();
+            var thirdMetricType = thirdMetric.ConvertToEnum<EMetric>();
+            var frametimeMetricTypes = useDisplayChangeMetrics
+                ? new[] { EMetric.Average }
+                : new[] { EMetric.Average, secondMetricType, thirdMetricType };
+            var frametimeMetricValues = GetFpsMetricValues(frametimes, frametimeMetricTypes);
 
+            var average = frametimeMetricValues[EMetric.Average];
             double secondMetricValue;
             double thrirdMetricValue;
 
-            if (!useDisplayChangeMetrics)
+            if (useDisplayChangeMetrics)
             {
-                secondMetricValue = GetFpsMetricValue(frametimes, secondMetric.ConvertToEnum<EMetric>());
-                thrirdMetricValue = GetFpsMetricValue(frametimes, thirdMetric.ConvertToEnum<EMetric>());
+                var displayMetricValues = GetFpsMetricValues(displaytimes,
+                    new[] { secondMetricType, thirdMetricType });
+                secondMetricValue = displayMetricValues[secondMetricType];
+                thrirdMetricValue = displayMetricValues[thirdMetricType];
             }
             else
             {
-                secondMetricValue = GetFpsMetricValue(displaytimes, secondMetric.ConvertToEnum<EMetric>());
-                thrirdMetricValue = GetFpsMetricValue(displaytimes, thirdMetric.ConvertToEnum<EMetric>());
+                secondMetricValue = frametimeMetricValues[secondMetricType];
+                thrirdMetricValue = frametimeMetricValues[thirdMetricType];
             }
 
             string numberFormat = string.Format("F{0}", _options.FpsValuesRoundingDigits);
             var cultureInfo = CultureInfo.InvariantCulture;
 
             string secondMetricString =
-                secondMetric.ConvertToEnum<EMetric>() != EMetric.None ?
-                " | " + $"{secondMetric.ConvertToEnum<EMetric>().GetShortDescription()}=" +
+                secondMetricType != EMetric.None ?
+                " | " + $"{secondMetricType.GetShortDescription()}=" +
                 $"{secondMetricValue.ToString(numberFormat, cultureInfo)} " +
                 $"FPS" : string.Empty;
 
             string thirdMetricString =
-                thirdMetric.ConvertToEnum<EMetric>() != EMetric.None ?
-                " | " + $"{thirdMetric.ConvertToEnum<EMetric>().GetShortDescription()}=" +
+                thirdMetricType != EMetric.None ?
+                " | " + $"{thirdMetricType.GetShortDescription()}=" +
                 $"{thrirdMetricValue.ToString(numberFormat, cultureInfo)} " +
                 $"FPS" : string.Empty;
 
@@ -699,100 +1041,65 @@ namespace CapFrameX.Statistics.NetStandard
         public IList<double> GetFrametimeVariancePercentages(ISession session)
         {
             if (!session.Runs.Any())
-                return new List<double>();
+                return new double[5];
 
-            // Create bins for variance thresholds
-            int threshold2Count = 0;
-            int threshold4Count = 0;
-            int threshold8Count = 0;
-            int threshold12Count = 0;
-            int thresholdOver12Count = 0;
-
-            // Get frametime variances
-            double varianceCount = 0.0;
-            foreach (var run in session.Runs)
-            {
-                var frametimes = run.CaptureData.MsBetweenPresents.ToArray();
-                for (int i = 1; i < frametimes.Count(); i++)
-                {
-                    double variance = Math.Abs(frametimes[i] - frametimes[i - 1]);
-
-                    if (variance < 2)
-                        threshold2Count++;
-                    else if (variance < 4)
-                        threshold4Count++;
-                    else if (variance < 8)
-                        threshold8Count++;
-                    else if (variance < 12)
-                        threshold12Count++;
-                    else
-                        thresholdOver12Count++;
-
-                    varianceCount++;
-                }
-            }
-
-
-            // Add percentage of variance bins to List
-            IList<double> variancePercentages = new List<double>
-            {
-                Math.Round(threshold2Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold4Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold8Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold12Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(thresholdOver12Count / varianceCount, 4, MidpointRounding.AwayFromZero)
-            };
-
-            return variancePercentages;
+            return GetVariancePercentages(session.Runs
+                .Select(run => (IList<double>)run.CaptureData.MsBetweenPresents));
         }
 
         public IList<double> GetDisplayTimeVariancePercentages(ISession session)
         {
             if (!session.Runs.Any())
-                return new List<double>();
+                return new double[5];
 
-            // Create bins for variance thresholds
-            int threshold2Count = 0;
-            int threshold4Count = 0;
-            int threshold8Count = 0;
-            int threshold12Count = 0;
-            int thresholdOver12Count = 0;
+            return GetVariancePercentages(session.Runs
+                .Select(run => (IList<double>)run.CaptureData.MsBetweenDisplayChange));
+        }
 
-            // Get frametime variances
-            double varianceCount = 0.0;
-            foreach (var run in session.Runs)
+        public IList<double> GetVariancePercentages(IList<double> sequence)
+        {
+            return GetVariancePercentages(new[] { sequence });
+        }
+
+        private static IList<double> GetVariancePercentages(IEnumerable<IList<double>> sequences)
+        {
+            var thresholds = new int[5];
+            var varianceCount = 0;
+
+            foreach (var sequence in sequences.Where(candidate => candidate != null))
             {
-                var displayTimes = run.CaptureData.MsBetweenDisplayChange.ToArray();
-                for (int i = 1; i < displayTimes.Count(); i++)
+                for (int i = 1; i < sequence.Count; i++)
                 {
-                    double variance = Math.Abs(displayTimes[i] - displayTimes[i - 1]);
+                    var previous = sequence[i - 1];
+                    var current = sequence[i];
+                    if (double.IsNaN(previous) || double.IsInfinity(previous)
+                        || double.IsNaN(current) || double.IsInfinity(current))
+                    {
+                        continue;
+                    }
 
+                    var variance = Math.Abs(current - previous);
                     if (variance < 2)
-                        threshold2Count++;
+                        thresholds[0]++;
                     else if (variance < 4)
-                        threshold4Count++;
+                        thresholds[1]++;
                     else if (variance < 8)
-                        threshold8Count++;
+                        thresholds[2]++;
                     else if (variance < 12)
-                        threshold12Count++;
+                        thresholds[3]++;
                     else
-                        thresholdOver12Count++;
+                        thresholds[4]++;
 
                     varianceCount++;
                 }
             }
 
-            // Add percentage of variance bins to List
-            IList<double> variancePercentages = new List<double>
-            {
-                Math.Round(threshold2Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold4Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold8Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold12Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(thresholdOver12Count / varianceCount, 4, MidpointRounding.AwayFromZero)
-            };
+            if (varianceCount == 0)
+                return new double[5];
 
-            return variancePercentages;
+            return thresholds
+                .Select(count => Math.Round((double)count / varianceCount, 4, MidpointRounding.AwayFromZero))
+                .ToList();
         }
     }
 }

--- a/source/CapFrameX.Statistics.NetStandard/SessionExtensions.cs
+++ b/source/CapFrameX.Statistics.NetStandard/SessionExtensions.cs
@@ -4,135 +4,363 @@ using CapFrameX.Statistics.NetStandard.Contracts;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace CapFrameX.Statistics.NetStandard
 {
-    public static class SessionExtensions
-    {
-		private static IList<double> FilterDataWithinTimeWindow(IList<double> startTimes, IList<double> data, double startTime, double endTime)
+	public static class SessionExtensions
+	{
+		[Flags]
+		private enum TimingSeries
 		{
-			return startTimes.Zip(data, (t, y) => new { t, y })
-					 .Where(pair => pair.t >= startTime && pair.t <= endTime)
-					 .Select(pair => pair.y)
-					 .ToList();
+			StartTimes = 1,
+			Frametimes = 2,
+			DisplayChangeTimes = 4,
+			GpuActiveTimes = 8,
+			CpuActiveTimes = 16,
+			AnimationErrors = 32,
+			PcLatencies = 64
 		}
 
-		private static IList<Point> FilterDataPointsWithinTimeWindow(IList<double> startTimes, IList<double> data, double startTime, double endTime)
+		private sealed class SessionTimingData
 		{
-			return startTimes.Zip(data, (t, y) => new Point(t, y))
-					 .Where(point => point.X >= startTime && point.X <= endTime)
-					 .ToList();
+			public ISessionRun[] Runs;
+			public ISessionCaptureData[] CaptureData;
+			public double[][] StartTimeSources;
+			public double[][] FrametimeSources;
+			public double[][] DisplayChangeSources;
+			public double[][] GpuActiveSources;
+			public double[][] CpuActiveSources;
+			public double[][] AnimationErrorSources;
+			public double[][] PcLatencySources;
+			public double[] StartTimes;
+			public double[] Frametimes;
+			public double[] DisplayChangeTimes;
+			public double[] GpuActiveTimes;
+			public double[] CpuActiveTimes;
+			public double[] AnimationErrors;
+			public double[] PcLatencies;
 		}
+
+		private static readonly ConditionalWeakTable<ISession, SessionTimingData> TimingDataCache =
+			new ConditionalWeakTable<ISession, SessionTimingData>();
+
+		private static SessionTimingData GetTimingData(ISession session, TimingSeries requestedSeries)
+		{
+			var timingData = TimingDataCache.GetValue(session, _ => new SessionTimingData());
+			lock (timingData)
+			{
+				if (!IsTimingStructureCurrent(session, timingData))
+				{
+					timingData.Runs = session?.Runs?.ToArray() ?? Array.Empty<ISessionRun>();
+					timingData.CaptureData = timingData.Runs
+						.Select(run => run?.CaptureData).ToArray();
+					ClearTimingSeries(timingData);
+				}
+
+				if ((requestedSeries & TimingSeries.StartTimes) != 0)
+					EnsureTimingSeries(session, timingData, data => data.TimeInSeconds,
+						run => run.CaptureData.TimeInSeconds, ref timingData.StartTimeSources, ref timingData.StartTimes);
+				if ((requestedSeries & TimingSeries.Frametimes) != 0)
+					EnsureTimingSeries(session, timingData, data => data.MsBetweenPresents,
+						run => run.CaptureData.MsBetweenPresents, ref timingData.FrametimeSources, ref timingData.Frametimes);
+				if ((requestedSeries & TimingSeries.DisplayChangeTimes) != 0)
+					EnsureTimingSeries(session, timingData, data => data.MsBetweenDisplayChange,
+						run => run.CaptureData.MsBetweenDisplayChange, ref timingData.DisplayChangeSources, ref timingData.DisplayChangeTimes);
+				if ((requestedSeries & TimingSeries.GpuActiveTimes) != 0)
+					EnsureTimingSeries(session, timingData, data => data.GpuActive,
+						run => run.CaptureData.GpuActive, ref timingData.GpuActiveSources, ref timingData.GpuActiveTimes);
+				if ((requestedSeries & TimingSeries.CpuActiveTimes) != 0)
+					EnsureTimingSeries(session, timingData, data => data.CpuActive,
+						run => run.CaptureData.CpuActive, ref timingData.CpuActiveSources, ref timingData.CpuActiveTimes);
+				if ((requestedSeries & TimingSeries.AnimationErrors) != 0)
+					EnsureTimingSeries(session, timingData, data => data.AnimationError,
+						run => run.CaptureData.AnimationError, ref timingData.AnimationErrorSources, ref timingData.AnimationErrors);
+				if ((requestedSeries & TimingSeries.PcLatencies) != 0)
+					EnsureTimingSeries(session, timingData, data => data.PcLatency,
+						run => run.CaptureData.PcLatency, ref timingData.PcLatencySources, ref timingData.PcLatencies);
+
+				return timingData;
+			}
+		}
+
+		private static bool IsTimingStructureCurrent(ISession session, SessionTimingData timingData)
+		{
+			if (session?.Runs == null || timingData.Runs == null
+				|| timingData.Runs.Length != session.Runs.Count)
+				return false;
+
+			for (int i = 0; i < timingData.Runs.Length; i++)
+			{
+				var run = session.Runs[i];
+				var captureData = run?.CaptureData;
+				if (!ReferenceEquals(timingData.Runs[i], run)
+					|| !ReferenceEquals(timingData.CaptureData[i], captureData))
+					return false;
+			}
+
+			return true;
+		}
+
+		private static void EnsureTimingSeries(ISession session, SessionTimingData timingData,
+			Func<ISessionCaptureData, double[]> captureSelector, Func<ISessionRun, double[]> runSelector,
+			ref double[][] sources, ref double[] flattened)
+		{
+			bool isCurrent = sources != null && sources.Length == timingData.CaptureData.Length;
+			if (isCurrent)
+			{
+				for (int i = 0; i < sources.Length; i++)
+				{
+					var current = timingData.CaptureData[i] == null
+						? null : captureSelector(timingData.CaptureData[i]);
+					if (!ReferenceEquals(sources[i], current))
+					{
+						isCurrent = false;
+						break;
+					}
+				}
+			}
+
+			if (isCurrent && timingData.Runs.Length > 1)
+				isCurrent = FlattenedValuesMatch(sources, flattened);
+
+			if (!isCurrent)
+			{
+				sources = GetSourceArrays(timingData.CaptureData, captureSelector);
+				flattened = FlattenOrReuse(session, runSelector);
+			}
+		}
+
+		private static void ClearTimingSeries(SessionTimingData timingData)
+		{
+			timingData.StartTimeSources = null;
+			timingData.FrametimeSources = null;
+			timingData.DisplayChangeSources = null;
+			timingData.GpuActiveSources = null;
+			timingData.CpuActiveSources = null;
+			timingData.AnimationErrorSources = null;
+			timingData.PcLatencySources = null;
+			timingData.StartTimes = null;
+			timingData.Frametimes = null;
+			timingData.DisplayChangeTimes = null;
+			timingData.GpuActiveTimes = null;
+			timingData.CpuActiveTimes = null;
+			timingData.AnimationErrors = null;
+			timingData.PcLatencies = null;
+		}
+
+		private static bool FlattenedValuesMatch(double[][] sources, double[] flattened)
+		{
+			int index = 0;
+			foreach (var source in sources)
+			{
+				if (source == null)
+					continue;
+
+				for (int i = 0; i < source.Length; i++)
+				{
+					if (index >= flattened.Length
+						|| BitConverter.DoubleToInt64Bits(source[i]) != BitConverter.DoubleToInt64Bits(flattened[index]))
+						return false;
+					index++;
+				}
+			}
+
+			return index == flattened.Length;
+		}
+
+		private static double[][] GetSourceArrays(ISessionCaptureData[] captureData,
+			Func<ISessionCaptureData, double[]> selector)
+		{
+			return captureData.Select(data => data == null ? null : selector(data)).ToArray();
+		}
+
+		private static T[] FlattenOrReuse<T>(ISession session, Func<ISessionRun, T[]> selector)
+		{
+			if (session?.Runs == null || session.Runs.Count == 0)
+				return Array.Empty<T>();
+			if (session.Runs.Count == 1)
+				return selector(session.Runs[0]) ?? Array.Empty<T>();
+
+			return session.Runs.SelectMany(run => selector(run) ?? Array.Empty<T>()).ToArray();
+		}
+
+		private static IList<double> FilterDataWithinTimeWindow(IList<double> startTimes, IList<double> data,
+            double startTime, double endTime, FrametimeStatisticProvider statisticProvider = null,
+            ERemoveOutlierMethod removeOutlierMethod = ERemoveOutlierMethod.None,
+            Func<double, bool> isValidValue = null)
+		{
+            int count = Math.Min(startTimes.Count, data.Count);
+            var filteredData = new List<double>(count);
+            var valueValidator = isValidValue ?? IsValidTimingValue;
+
+            for (int i = 0; i < count; i++)
+            {
+                double time = startTimes[i];
+                double value = data[i];
+
+                if (time >= startTime && time <= endTime && valueValidator(value))
+                {
+                    filteredData.Add(value);
+                }
+            }
+
+            return statisticProvider == null
+                ? filteredData
+                : statisticProvider.GetOutlierAdjustedSequence(filteredData, removeOutlierMethod);
+		}
+
+		private static IList<Point> FilterDataPointsWithinTimeWindow(IList<double> startTimes, IList<double> data,
+            double startTime, double endTime, FrametimeStatisticProvider statisticProvider = null,
+            ERemoveOutlierMethod removeOutlierMethod = ERemoveOutlierMethod.None,
+            Func<double, bool> isValidValue = null)
+		{
+            int count = Math.Min(startTimes.Count, data.Count);
+            var filteredPoints = new List<Point>(count);
+            var valueValidator = isValidValue ?? IsValidTimingValue;
+
+            for (int i = 0; i < count; i++)
+            {
+                double time = startTimes[i];
+                double value = data[i];
+
+                if (time >= startTime && time <= endTime && valueValidator(value))
+                {
+                    filteredPoints.Add(new Point(time, value));
+                }
+            }
+
+            if (removeOutlierMethod == ERemoveOutlierMethod.DeciPercentile && filteredPoints.Count > 0)
+            {
+                var adjustedValues = statisticProvider.GetOutlierAdjustedSequence(
+                    filteredPoints.Select(point => point.Y).ToArray(), removeOutlierMethod);
+                var remainingValueCounts = adjustedValues
+                    .GroupBy(value => value)
+                    .ToDictionary(group => group.Key, group => group.Count());
+                var adjustedPoints = new List<Point>(adjustedValues.Count);
+
+                foreach (Point point in filteredPoints)
+                {
+                    int remainingCount;
+                    if (remainingValueCounts.TryGetValue(point.Y, out remainingCount) && remainingCount > 0)
+                    {
+                        adjustedPoints.Add(point);
+                        remainingValueCounts[point.Y] = remainingCount - 1;
+                    }
+                }
+
+                return adjustedPoints;
+            }
+
+            return filteredPoints;
+		}
+
+        private static bool IsValidTimingValue(double value)
+        {
+            return value > 0 && !double.IsNaN(value) && !double.IsInfinity(value);
+        }
+
+        private static bool IsValidActiveTimeValue(double value)
+        {
+            return value >= 0 && !double.IsNaN(value) && !double.IsInfinity(value);
+        }
 
 		public static IList<double> GetFrametimeTimeWindow(this ISession session, double startTime, double endTime,
             IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
         {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
-            var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var frametimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.Frametimes);
 
-            return FilterDataWithinTimeWindow(frameStartTimes, frametimes, startTime, endTime);
+            return FilterDataWithinTimeWindow(timingData.StartTimes, timingData.Frametimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod);
         }
 
         public static IList<double> GetDisplayChangeTimeWindow(this ISession session, double startTime, double endTime,
             IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
         {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
-            var dispalyStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var displayChangeTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.DisplayChangeTimes);
 
-            return FilterDataWithinTimeWindow(dispalyStartTimes, displayChangeTimes, startTime, endTime);
+            return FilterDataWithinTimeWindow(timingData.StartTimes, timingData.DisplayChangeTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod);
         }
 
         public static IList<double> GetGpuActiveTimeTimeWindow(this ISession session, double startTime, double endTime,
 			IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
 		{
 			var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
-			var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.GpuActiveTimes);
 
-            var gpuActiveTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.GpuActive).ToArray(), eRemoveOutlierMethod)
-				?? Enumerable.Empty<double>().ToList();
-
-			return FilterDataWithinTimeWindow(frameStartTimes, gpuActiveTimes, startTime, endTime);
+			return FilterDataWithinTimeWindow(timingData.StartTimes, timingData.GpuActiveTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod, IsValidActiveTimeValue);
 		}
 
         public static IList<double> GetCpuActiveTimeTimeWindow(this ISession session, double startTime, double endTime,
             IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
         {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
-            var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.CpuActiveTimes);
 
-            var cpuActiveTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.CpuActive).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
-
-            return FilterDataWithinTimeWindow(frameStartTimes, cpuActiveTimes, startTime, endTime);
+            return FilterDataWithinTimeWindow(timingData.StartTimes, timingData.CpuActiveTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod, IsValidActiveTimeValue);
         }
 
         public static IList<double> GetAnimationErrorTimeWindow(this ISession session, double startTime, double endTime)
         {
-            var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var animationErrors = session.Runs.SelectMany(r => r.CaptureData.AnimationError).ToArray();
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.AnimationErrors);
+            int count = Math.Min(timingData.StartTimes.Length, timingData.AnimationErrors.Length);
+            var values = new List<double>(count);
 
-            return frameStartTimes.Zip(animationErrors, (t, y) => new { t, y })
-                .Where(pair => pair.t >= startTime && pair.t <= endTime && !double.IsNaN(pair.y))
-                .Select(pair => pair.y)
-                .ToList();
+            for (int i = 0; i < count; i++)
+            {
+                if (timingData.StartTimes[i] >= startTime && timingData.StartTimes[i] <= endTime
+                    && !double.IsNaN(timingData.AnimationErrors[i]) && !double.IsInfinity(timingData.AnimationErrors[i]))
+                {
+                    values.Add(timingData.AnimationErrors[i]);
+                }
+            }
+
+            return values;
         }
 
         public static IList<Point> GetFrametimePointsTimeWindow(this ISession session, double startTime, double endTime,
             IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
         {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
-			var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-			var frametimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToArray(), eRemoveOutlierMethod)
-				?? Enumerable.Empty<double>().ToList();
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.Frametimes);
 
-			return FilterDataPointsWithinTimeWindow(frameStartTimes, frametimes, startTime, endTime);
+			return FilterDataPointsWithinTimeWindow(timingData.StartTimes, timingData.Frametimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod);
         }
 
         public static IList<Point> GetDisplayChangeTimePointsTimeWindow(this ISession session, double startTime, double endTime,
             IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
         {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
-            var displayStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var displayChangeTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.DisplayChangeTimes);
 
-            return FilterDataPointsWithinTimeWindow(displayStartTimes, displayChangeTimes, startTime, endTime);
+            return FilterDataPointsWithinTimeWindow(timingData.StartTimes, timingData.DisplayChangeTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod);
         }
 
         public static IList<Point> GetGpuActiveTimePointsTimeWindow(this ISession session, double startTime, double endTime,
 			IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
 		{
 			var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
-			var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.GpuActiveTimes);
 
-			var gpuActiveTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.GpuActive).ToArray(), eRemoveOutlierMethod)
-				?? Enumerable.Empty<double>().ToList();
-
-			return FilterDataPointsWithinTimeWindow(frameStartTimes, gpuActiveTimes, startTime, endTime);
+			return FilterDataPointsWithinTimeWindow(timingData.StartTimes, timingData.GpuActiveTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod, IsValidActiveTimeValue);
 		}
 
         public static IList<Point> GetCpuActiveTimePointsTimeWindow(this ISession session, double startTime, double endTime,
             IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
         {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
-            var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.CpuActiveTimes);
 
-            var cpuActiveTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.CpuActive).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
-
-            return FilterDataPointsWithinTimeWindow(frameStartTimes, cpuActiveTimes, startTime, endTime);
+            return FilterDataPointsWithinTimeWindow(timingData.StartTimes, timingData.CpuActiveTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod, IsValidActiveTimeValue);
         }
 
 		public static IList<Point> GetFrametimePoints(this ISession session)
@@ -472,12 +700,10 @@ namespace CapFrameX.Statistics.NetStandard
         {
             var list = new List<Point>();
 
-            if (session.Runs.Any(r => r.SensorData2 == null))
-                return list;
-
-            var times = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var latencies = session.Runs.SelectMany(r => r.CaptureData.PcLatency).ToArray();
-            int count = Math.Min(times.Count(), latencies.Count());
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.PcLatencies);
+            var times = timingData.StartTimes;
+            var latencies = timingData.PcLatencies;
+            int count = Math.Min(times.Length, latencies.Length);
 
             if (latencies.Any())
             {
@@ -494,9 +720,10 @@ namespace CapFrameX.Statistics.NetStandard
         {
             var list = new List<Point>();
 
-            var times = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var animationErrors = session.Runs.SelectMany(r => r.CaptureData.AnimationError).ToArray();
-            int count = Math.Min(times.Count(), animationErrors.Count());
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.AnimationErrors);
+            var times = timingData.StartTimes;
+            var animationErrors = timingData.AnimationErrors;
+            int count = Math.Min(times.Length, animationErrors.Length);
 
             if (animationErrors.Any())
             {
@@ -520,8 +747,9 @@ namespace CapFrameX.Statistics.NetStandard
                 case EFilterMode.TimeIntervalAverage:
                     var intervalFrametimePoints = session.GetFrametimePointsTimeWindow(0, endTime, options, eRemoveOutlierMethod);
                     var timeIntervalAverageFilter = new IntervalTimeAverageFilter(options.IntervalAverageWindowTime);
+                    var timingData = GetTimingData(session, TimingSeries.StartTimes);
                     var timeIntervalAveragePoints = timeIntervalAverageFilter
-                        .ProcessSamples(intervalFrametimePoints, startTime, endTime, session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).Last());
+                        .ProcessSamples(intervalFrametimePoints, startTime, endTime, timingData.StartTimes.Last());
                     fpsPoints = timeIntervalAveragePoints.Select(pnt => new Point(pnt.X, 1000 / pnt.Y)).ToList();
                     break;
                 default:
@@ -544,8 +772,9 @@ namespace CapFrameX.Statistics.NetStandard
                 case EFilterMode.TimeIntervalAverage:
                     var intervalDisplayChangeTimePoints = session.GetDisplayChangeTimePointsTimeWindow(0, endTime, options, eRemoveOutlierMethod);
                     var timeIntervalAverageFilter = new IntervalTimeAverageFilter(options.IntervalAverageWindowTime);
+                    var timingData = GetTimingData(session, TimingSeries.StartTimes);
                     var timeIntervalAveragePoints = timeIntervalAverageFilter
-                        .ProcessSamples(intervalDisplayChangeTimePoints, startTime, endTime, session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).Last());
+                        .ProcessSamples(intervalDisplayChangeTimePoints, startTime, endTime, timingData.StartTimes.Last());
                     displayFpsPoints = timeIntervalAveragePoints.Select(pnt => new Point(pnt.X, 1000 / pnt.Y)).ToList();
                     break;
                 default:
@@ -568,8 +797,9 @@ namespace CapFrameX.Statistics.NetStandard
 				case EFilterMode.TimeIntervalAverage:
                     var intervalGpuActiveTimePoints = session.GetGpuActiveTimePointsTimeWindow(0, endTime, options, eRemoveOutlierMethod);
                     var timeIntervalAverageFilter = new IntervalTimeAverageFilter(options.IntervalAverageWindowTime);
+					var timingData = GetTimingData(session, TimingSeries.StartTimes);
 					var timeIntervalAveragePoints = timeIntervalAverageFilter
-						.ProcessSamples(intervalGpuActiveTimePoints, startTime, endTime, session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).Last());
+						.ProcessSamples(intervalGpuActiveTimePoints, startTime, endTime, timingData.StartTimes.Last());
 					fpsPoints = timeIntervalAveragePoints.Select(pnt => new Point(pnt.X, 1000 / pnt.Y)).ToList();
 					break;
 				default:
@@ -619,58 +849,69 @@ namespace CapFrameX.Statistics.NetStandard
         public static IList<Point> GetFrametimeDistributionPoints(this ISession session, double startTime, double endTime,
             IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
         {
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.Frametimes);
 
+            return GetTimingDistributionPoints(timingData.StartTimes, timingData.Frametimes, startTime, endTime,
+                options, eRemoveOutlierMethod);
+        }
+
+        public static IList<Point> GetDisplayTimeDistributionPoints(this ISession session, double startTime, double endTime,
+            IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
+        {
+            var timingData = GetTimingData(session, TimingSeries.StartTimes | TimingSeries.DisplayChangeTimes);
+
+            return GetTimingDistributionPoints(timingData.StartTimes, timingData.DisplayChangeTimes, startTime, endTime,
+                options, eRemoveOutlierMethod);
+        }
+
+        private static IList<Point> GetTimingDistributionPoints(IList<double> frameStartTimes, IList<double> timingValues,
+            double startTime, double endTime, IFrametimeStatisticProviderOptions options,
+            ERemoveOutlierMethod eRemoveOutlierMethod)
+        {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
-            var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var frametimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
+            var filteredFrameTimes = FilterDataWithinTimeWindow(frameStartTimes, timingValues, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod);
 
-            var filteredFrameTimes = FilterDataWithinTimeWindow(frameStartTimes, frametimes, startTime, endTime);
+            if (filteredFrameTimes.Count == 0)
+            {
+                return new List<Point>();
+            }
 
-            // Bin increments
-            double increments = 0.1;
+            const double increment = 0.1;
             double maxValue = filteredFrameTimes.Max();
-
-
-            // Create Bins (start, end)
-            List<(double start, double end)> bins = new List<(double, double)>();
-            for (double start = 0; start < maxValue; start += increments)
-            {
-                double end = Math.Round(start + increments, 10);
-                bins.Add((start, end));
-            }
-
-            // Expand last bin if maxValue doesn't fit
-            if (bins.Count == 0 || bins.Last().end < maxValue)
-            {
-                double start = bins.Count > 0 ? bins.Last().end : 0;
-                double end = Math.Round(start + increments, 10);
-                bins.Add((start, end));
-            }
-
-
-            // Distribution list (X = bin threshold, Y = percentage)
             double totalSum = filteredFrameTimes.Sum();
-            List<Point> frametimeDistribution = new List<Point>();
+            var binSums = new Dictionary<int, double>();
 
-            foreach (var (start, end) in bins)
+            // Build only populated bins. This is O(samples) and cannot allocate a huge
+            // dense array when a capture contains a very large hitch.
+            for (int i = 0; i < filteredFrameTimes.Count; i++)
             {
-                bool isLastBin = (start, end) == bins.Last();
+                double value = filteredFrameTimes[i];
+                double scaledValue = value / increment;
+                double roundedScaledValue = Math.Round(scaledValue);
+                if (Math.Abs(scaledValue - roundedScaledValue) < 1E-9)
+                    scaledValue = roundedScaledValue;
 
-                // sum of values in bin
-                double binSum = filteredFrameTimes
-                    .Where(w => isLastBin ? (w >= start && w <= end) : (w >= start && w < end))
-                    .Sum();
+                int binIndex = (int)Math.Floor(scaledValue);
 
-                if (binSum > 0 )
+                // Bins are [start, end), except for the final bin which includes
+                // the maximum. Keep an exact maximum boundary in that final bin.
+                if (value == maxValue && binIndex > 0 && scaledValue == roundedScaledValue)
                 {
-                    double percentage = (binSum / totalSum) * 100;
-                    frametimeDistribution.Add(new Point(end, percentage));
+                    binIndex--;
                 }
+
+                double currentSum;
+                binSums.TryGetValue(binIndex, out currentSum);
+                binSums[binIndex] = currentSum + value;
             }
 
-            return frametimeDistribution;
+            return binSums
+                .OrderBy(pair => pair.Key)
+                .Select(pair => new Point(
+                    Math.Round((pair.Key + 1) * increment, 10),
+                    pair.Value / totalSum * 100))
+                .ToList();
         }
     }
 }

--- a/source/CapFrameX.Statistics.PlotBuilder/FpsGraphPlotBuilder.cs
+++ b/source/CapFrameX.Statistics.PlotBuilder/FpsGraphPlotBuilder.cs
@@ -16,51 +16,93 @@ namespace CapFrameX.Statistics.PlotBuilder
         public void BuildPlotmodel(ISession session, IPlotSettings plotSettings, double startTime, double endTime, ERemoveOutlierMethod eRemoveOutlinerMethod, EFilterMode filterMode, Action<PlotModel> onFinishAction = null)
         {
             var plotModel = PlotModel;
-            Reset();
+            Reset(false);
 
-            if (session == null) return;
+            if (session == null)
+            {
+                // Reset(false) skipped the redraw; render the cleared model so no
+                // stale chart from a previously selected record stays on screen.
+                plotModel.InvalidatePlot(true);
+                return;
+            }
 
             plotModel.Axes.Add(AxisDefinitions[EPlotAxis.XAXIS]);
             plotModel.Axes.Add(AxisDefinitions[EPlotAxis.YAXISFPS]);
 
-            var frametimes = session.GetFrametimeTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod);
-            double average = frametimes.Count * 1000 / frametimes.Sum();
+            var useDisplayTimes = plotSettings.ShowDisplayTimes;
+            var timingValues = useDisplayTimes
+                ? session.GetDisplayChangeTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod)
+                : session.GetFrametimeTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod);
+
+            // PresentMon does not expose display-change data for every graphics API.
+            // Match the current capture pipeline behavior and fall back to presents.
+            if (useDisplayTimes && timingValues.Count == 0)
+            {
+                useDisplayTimes = false;
+                timingValues = session.GetFrametimeTimeWindow(startTime, endTime,
+                    _frametimeStatisticProviderOptions, eRemoveOutlinerMethod);
+            }
+
+            if (timingValues.Count == 0)
+            {
+                plotModel.InvalidatePlot(true);
+                return;
+            }
+
+            double average = timingValues.Count * 1000 / timingValues.Sum();
             double yMin, yMax;
 
             plotModel.Series.Clear();
 
-            var rawFpsPoints = session.GetFpsPointsTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod, EFilterMode.None);
+            var rawFpsPoints = GetFpsPoints(session, useDisplayTimes, startTime, endTime,
+                eRemoveOutlinerMethod, EFilterMode.None);
             IList<Point> gpuActiveFpsPoints = new List<Point>();
 
             if (filterMode is EFilterMode.RawPlusAverage)
             {
-                var avgFpsPoints = session.GetFpsPointsTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod, EFilterMode.TimeIntervalAverage);
+                var avgFpsPoints = GetFpsPoints(session, useDisplayTimes, startTime, endTime,
+                    eRemoveOutlinerMethod, EFilterMode.TimeIntervalAverage);
+
+                if (rawFpsPoints.Count == 0 || avgFpsPoints.Count == 0)
+                {
+                    plotModel.InvalidatePlot(true);
+                    return;
+                }
 
                 //if (plotSettings.ShowGpuActiveCharts)
                 //    gpuActiveFpsPoints = session.GetGpuActiveFpsPointsTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod, filterMode);
 
-                SetRawFPS(plotModel, rawFpsPoints);
-                SetLoadCharts(plotModel, plotSettings, session);
-                SetFpsChart(plotModel, avgFpsPoints, rawFpsPoints, gpuActiveFpsPoints, average, 3, OxyColor.FromRgb(241, 125, 32), filterMode, plotSettings);
+                SetRawFPS(plotModel, rawFpsPoints, useDisplayTimes);
+                SetLoadCharts(plotModel, plotSettings, session, startTime, endTime);
+                SetFpsChart(plotModel, avgFpsPoints, rawFpsPoints, gpuActiveFpsPoints, average, 3,
+                    OxyColor.FromRgb(241, 125, 32), filterMode, plotSettings, useDisplayTimes);
 
                 yMin = rawFpsPoints.Min(pnt => pnt.Y);
                 yMax = rawFpsPoints.Max(pnt => pnt.Y);
             }
             else
             {
-                var fpsPoints = session.GetFpsPointsTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod, filterMode);
+                var fpsPoints = GetFpsPoints(session, useDisplayTimes, startTime, endTime,
+                    eRemoveOutlinerMethod, filterMode);
+                if (fpsPoints.Count == 0)
+                {
+                    plotModel.InvalidatePlot(true);
+                    return;
+                }
 
                 //if (plotSettings.ShowGpuActiveCharts)
                 //    gpuActiveFpsPoints = session.GetGpuActiveFpsPointsTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod, filterMode);
 
                 if (filterMode == EFilterMode.TimeIntervalAverage)
-                    SetLoadCharts(plotModel, plotSettings, session);
+                    SetLoadCharts(plotModel, plotSettings, session, startTime, endTime);
 
-                SetFpsChart(plotModel, fpsPoints, rawFpsPoints, gpuActiveFpsPoints, average, filterMode is EFilterMode.None ? 1.5 : 3, Constants.FpsColor, filterMode, plotSettings);
+                SetFpsChart(plotModel, fpsPoints, rawFpsPoints, gpuActiveFpsPoints, average,
+                    filterMode is EFilterMode.None ? 1.5 : 3, Constants.FpsColor, filterMode,
+                    plotSettings, useDisplayTimes);
 
 
                 if (filterMode is EFilterMode.None)
-                    SetLoadCharts(plotModel, plotSettings, session);
+                    SetLoadCharts(plotModel, plotSettings, session, startTime, endTime);
 
                 yMin = fpsPoints.Min(pnt => pnt.Y);
                 yMax = fpsPoints.Max(pnt => pnt.Y);
@@ -90,37 +132,46 @@ namespace CapFrameX.Statistics.PlotBuilder
             plotModel.InvalidatePlot(true);
         }
 
-        private void SetLoadCharts(PlotModel plotModel, IPlotSettings plotSettings, ISession session)
+        private IList<Point> GetFpsPoints(ISession session, bool useDisplayTimes, double startTime, double endTime,
+            ERemoveOutlierMethod removeOutlierMethod, EFilterMode filterMode)
+        {
+            return useDisplayTimes
+                ? session.GetDisplayFpsPointsTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions,
+                    removeOutlierMethod, filterMode)
+                : session.GetFpsPointsTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions,
+                    removeOutlierMethod, filterMode);
+        }
+
+        private void SetLoadCharts(PlotModel plotModel, IPlotSettings plotSettings, ISession session,
+            double startTime, double endTime)
         {
             if (plotSettings.IsAnyPercentageGraphVisible && session.HasValidSensorData())
             {
                 plotModel.Axes.Add(AxisDefinitions[EPlotAxis.YAXISPERCENTAGE]);
 
                 if (plotSettings.ShowGpuLoad)
-                    SetGPULoadChart(plotModel, session.GetGPULoadPointTimeWindow());
+                    SetGPULoadChart(plotModel, GetRenderablePoints(session.GetGPULoadPointTimeWindow(), startTime, endTime));
                 if (plotSettings.ShowCpuLoad)
-                    SetCPULoadChart(plotModel, session.GetCPULoadPointTimeWindow());
+                    SetCPULoadChart(plotModel, GetRenderablePoints(session.GetCPULoadPointTimeWindow(), startTime, endTime));
                 if (plotSettings.ShowCpuMaxThreadLoad)
-                    SetCPUMaxThreadLoadChart(plotModel, session.GetCPUMaxThreadLoadPointTimeWindow());
+                    SetCPUMaxThreadLoadChart(plotModel, GetRenderablePoints(session.GetCPUMaxThreadLoadPointTimeWindow(), startTime, endTime));
                 if (plotSettings.ShowGpuPowerLimit)
-                    SetGpuPowerLimitChart(plotModel, session.GetGpuPowerLimitPointTimeWindow());
+                    SetGpuPowerLimitChart(plotModel, GetRenderablePoints(session.GetGpuPowerLimitPointTimeWindow(), startTime, endTime));
             }
         }
 
-        private void SetFpsChart(PlotModel plotModel, IList<Point> fpsPoints, IList<Point> rawfpsPoints, IList<Point> gpuActiveFpsPoints, double average, double stroke, OxyColor color, EFilterMode filtermode, IPlotSettings plotSettings)
+        private void SetFpsChart(PlotModel plotModel, IList<Point> fpsPoints, IList<Point> rawfpsPoints,
+            IList<Point> gpuActiveFpsPoints, double average, double stroke, OxyColor color,
+            EFilterMode filtermode, IPlotSettings plotSettings, bool useDisplayTimes)
         {
             if (fpsPoints == null || !fpsPoints.Any())
                 return;
-
-            int count = fpsPoints.Count;
-            var fpsDataPoints = fpsPoints.Select(pnt => new DataPoint(pnt.X, pnt.Y));
-            var gpuActiveFpsDataPoints = gpuActiveFpsPoints.Select(pnt => new DataPoint(pnt.X, pnt.Y));
 
             // Filter mode = Raw+Average -> filtered average FPS
             // Filter mode = None -> Raw inverted frametimes
             var fpsSeries = new LineSeries
             {
-                Title = "FPS",
+                Title = useDisplayTimes ? "Display FPS" : "FPS",
                 StrokeThickness = stroke,
                 LegendStrokeThickness = 4,
                 Color = color,
@@ -139,7 +190,8 @@ namespace CapFrameX.Statistics.PlotBuilder
             //};
 
 
-            fpsSeries.Points.AddRange(fpsDataPoints);
+            fpsSeries.Points.AddRange(GetRenderablePoints(fpsPoints)
+                .Select(point => new DataPoint(point.X, point.Y)));
             plotModel.Series.Add(fpsSeries);
 
 
@@ -149,56 +201,47 @@ namespace CapFrameX.Statistics.PlotBuilder
             //    plotModel.Series.Add(gpuActiveFpsSeries);
             //}
 
-            var averageDataPoints = fpsPoints.Select(pnt => new DataPoint(pnt.X, average));
-
             var averageSeries = new LineSeries
             {
-                Title = "Avg FPS",
+                Title = useDisplayTimes ? "Avg Display FPS" : "Avg FPS",
                 StrokeThickness = 2,
                 LegendStrokeThickness = 4,
                 Color = OxyColor.FromAColor(200, Constants.FpsAverageColor)
             };
 
-            averageSeries.Points.AddRange(averageDataPoints);
+            averageSeries.Points.Add(new DataPoint(fpsPoints.First().X, average));
+            averageSeries.Points.Add(new DataPoint(fpsPoints.Last().X, average));
             plotModel.Series.Add(averageSeries);
 
 
             UpdateAxis(EPlotAxis.XAXIS, (axis) =>
             {
-                axis.Minimum = rawfpsPoints.First().X;
-                axis.Maximum = rawfpsPoints.Last().X;
-            });
-
-            plotModel.InvalidatePlot(true);
+                var axisPoints = rawfpsPoints != null && rawfpsPoints.Count > 0
+                    ? rawfpsPoints
+                    : fpsPoints;
+                axis.Minimum = axisPoints.First().X;
+                axis.Maximum = axisPoints.Last().X;
+            }, false);
         }
 
-        private void SetRawFPS(PlotModel plotModel, IList<Point> fpsPoints)
+        private void SetRawFPS(PlotModel plotModel, IList<Point> fpsPoints, bool useDisplayTimes)
         {
             // Only used when filter mode = Raw+Average
             var fpsSeries = new LineSeries
             {
-                Title = "Raw FPS",
+                Title = useDisplayTimes ? "Raw Display FPS" : "Raw FPS",
                 StrokeThickness = 1.5,
                 LegendStrokeThickness = 4,
                 Color = OxyColor.FromAColor(200, Constants.FpsColor),
                 EdgeRenderingMode = EdgeRenderingMode.PreferSpeed
             };
-            var points = fpsPoints.Select(pnt => new DataPoint(pnt.X, pnt.Y));
+            var points = GetRenderablePoints(fpsPoints).Select(pnt => new DataPoint(pnt.X, pnt.Y));
             fpsSeries.Points.AddRange(points);
             plotModel.Series.Add(fpsSeries);
-
-            plotModel.InvalidatePlot(true);
         }
 
         private void SetThresholdChart(PlotModel plotModel, IPlotSettings plotSettings, IList<Point> fpspoints)
         {
-            var lowFPS = new List<double>();
-
-            for (int i = 0; i < fpspoints.Count; i++)
-            {
-                lowFPS.Add(plotSettings.LowFPSThreshold);
-            }
-
             var lowFPSSeries = new LineSeries
             {
                 Title = "LowFPS",
@@ -209,7 +252,8 @@ namespace CapFrameX.Statistics.PlotBuilder
                 EdgeRenderingMode = EdgeRenderingMode.PreferSpeed
             };
 
-            lowFPSSeries.Points.AddRange(lowFPS.Select((y, i) => new DataPoint(fpspoints[i].X, y)));
+            lowFPSSeries.Points.Add(new DataPoint(fpspoints.First().X, plotSettings.LowFPSThreshold));
+            lowFPSSeries.Points.Add(new DataPoint(fpspoints.Last().X, plotSettings.LowFPSThreshold));
             plotModel.Series.Add(lowFPSSeries);
         }
 
@@ -233,7 +277,7 @@ namespace CapFrameX.Statistics.PlotBuilder
                     axis.Maximum = average + 5;
                 else
                     axis.Maximum = axisMaximum;
-            });
+            }, false);
         }
 
     }

--- a/source/CapFrameX.Statistics.PlotBuilder/FrametimeDistributionPlotBuilder.cs
+++ b/source/CapFrameX.Statistics.PlotBuilder/FrametimeDistributionPlotBuilder.cs
@@ -18,10 +18,13 @@ namespace CapFrameX.Statistics.PlotBuilder
         public void BuildPlotmodel(ISession session, IPlotSettings plotSettings, double startTime, double endTime, ERemoveOutlierMethod eRemoveOutlinerMethod, Action<PlotModel> onFinishAction = null)
         {
             var plotModel = PlotModel;
-            Reset();
+            Reset(false);
 
             if (session == null)
             {
+                // Reset(false) skipped the redraw; render the cleared model so no
+                // stale chart from a previously selected record stays on screen.
+                plotModel.InvalidatePlot(true);
                 return;
             }
 
@@ -29,13 +32,25 @@ namespace CapFrameX.Statistics.PlotBuilder
             plotModel.Axes.Add(AxisDefinitions[EPlotAxis.YAXISDISTRIBUTION]);
 
 
-            var frametimeDistributionPoints = session.GetFrametimeDistributionPoints(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod);
+            var useDisplayTimes = plotSettings.ShowDisplayTimes;
+            var frametimeDistributionPoints = useDisplayTimes
+                ? session.GetDisplayTimeDistributionPoints(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod)
+                : session.GetFrametimeDistributionPoints(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod);
 
+            if (useDisplayTimes && frametimeDistributionPoints.Count == 0)
+            {
+                useDisplayTimes = false;
+                frametimeDistributionPoints = session.GetFrametimeDistributionPoints(startTime, endTime,
+                    _frametimeStatisticProviderOptions, eRemoveOutlinerMethod);
+            }
 
-            IList<Point> GpuActiveTimePoints = new List<Point>();
+            if (frametimeDistributionPoints.Count == 0)
+            {
+                plotModel.InvalidatePlot(true);
+                return;
+            }
 
-
-            SetFrametimeDistributionChart(plotModel, frametimeDistributionPoints, plotSettings);
+            SetFrametimeDistributionChart(plotModel, frametimeDistributionPoints, useDisplayTimes);
 
 
             SetAggregationSeparators(session, plotModel, plotSettings.ShowAggregationSeparators);
@@ -74,19 +89,20 @@ namespace CapFrameX.Statistics.PlotBuilder
             plotModel.InvalidatePlot(true);
         }
 
-        private void SetFrametimeDistributionChart(PlotModel plotModel, IList<Point> frametimeDistributionPoints, IPlotSettings plotSettings)
+        private void SetFrametimeDistributionChart(PlotModel plotModel,
+            IList<Point> frametimeDistributionPoints, bool useDisplayTimes)
         {
             if (frametimeDistributionPoints == null || !frametimeDistributionPoints.Any())
                 return;
 
-            int count = frametimeDistributionPoints.Count;
-            var distributionDataPoints = frametimeDistributionPoints.Select(pnt => new DataPoint(pnt.X, pnt.Y));
+            var distributionDataPoints = GetRenderablePoints(frametimeDistributionPoints)
+                .Select(pnt => new DataPoint(pnt.X, pnt.Y));
 
             plotModel.Series.Clear();
 
             var distributionSeries = new LineSeries
             {
-                Title = "Distribution",
+                Title = useDisplayTimes ? "Display Time Distribution" : "Frame Time Distribution",
                 StrokeThickness = 3,
                 LegendStrokeThickness = 4,
                 Color = Constants.FrametimeColor,
@@ -100,12 +116,11 @@ namespace CapFrameX.Statistics.PlotBuilder
 
             UpdateAxis(EPlotAxis.XAXISFRAMETIMES, (axis) =>
             {
+                axis.Title = useDisplayTimes ? "Display time [ms]" : "Frametime [ms]";
                 axis.Minimum = frametimeDistributionPoints.First().X - 1;
                 axis.Maximum = frametimeDistributionPoints.Last().X + 1;
-            });
+            }, false);
             plotModel.Series.Add(distributionSeries);
-
-            plotModel.InvalidatePlot(true);
         }
 
         private void UpdateYAxisMaxBorder(double yMax)
@@ -129,7 +144,7 @@ namespace CapFrameX.Statistics.PlotBuilder
                      stepSize = 10;
 
                  axis.MajorStep = stepSize;
-             });
+             }, false);
         }
     }
 }

--- a/source/CapFrameX.Statistics.PlotBuilder/FrametimePlotBuilder.cs
+++ b/source/CapFrameX.Statistics.PlotBuilder/FrametimePlotBuilder.cs
@@ -16,10 +16,13 @@ namespace CapFrameX.Statistics.PlotBuilder
         public void BuildPlotmodel(ISession session, IPlotSettings plotSettings, double startTime, double endTime, ERemoveOutlierMethod eRemoveOutlinerMethod, Action<PlotModel> onFinishAction = null)
         {
             var plotModel = PlotModel;
-            Reset();
+            Reset(false);
 
             if (session == null)
             {
+                // Reset(false) skipped the redraw; render the cleared model so no
+                // stale chart from a previously selected record stays on screen.
+                plotModel.InvalidatePlot(true);
                 return;
             }
 
@@ -38,8 +41,6 @@ namespace CapFrameX.Statistics.PlotBuilder
             if (plotSettings.ShowCpuActiveCharts)
                 CpuActiveTimePoints = session.GetCpuActiveTimePointsTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod);
 
-            var frametimes = session.GetFrametimeTimeWindow(startTime, endTime, _frametimeStatisticProviderOptions, eRemoveOutlinerMethod); ;
-
             SetFrametimeChart(plotModel, frametimepoints, displaytimespoints, GpuActiveTimePoints, CpuActiveTimePoints, plotSettings);
 
             if (plotSettings.IsAnyPercentageGraphVisible && session.HasValidSensorData())
@@ -47,13 +48,13 @@ namespace CapFrameX.Statistics.PlotBuilder
                 plotModel.Axes.Add(AxisDefinitions[EPlotAxis.YAXISPERCENTAGE]);
 
                 if (plotSettings.ShowGpuLoad)
-                    SetGPULoadChart(plotModel, session.GetGPULoadPointTimeWindow());
+                    SetGPULoadChart(plotModel, GetRenderablePoints(session.GetGPULoadPointTimeWindow(), startTime, endTime));
                 if (plotSettings.ShowCpuLoad)
-                    SetCPULoadChart(plotModel, session.GetCPULoadPointTimeWindow());
+                    SetCPULoadChart(plotModel, GetRenderablePoints(session.GetCPULoadPointTimeWindow(), startTime, endTime));
                 if (plotSettings.ShowCpuMaxThreadLoad)
-                    SetCPUMaxThreadLoadChart(plotModel, session.GetCPUMaxThreadLoadPointTimeWindow());
+                    SetCPUMaxThreadLoadChart(plotModel, GetRenderablePoints(session.GetCPUMaxThreadLoadPointTimeWindow(), startTime, endTime));
                 if (plotSettings.ShowGpuPowerLimit)
-                    SetGpuPowerLimitChart(plotModel, session.GetGpuPowerLimitPointTimeWindow());
+                    SetGpuPowerLimitChart(plotModel, GetRenderablePoints(session.GetGpuPowerLimitPointTimeWindow(), startTime, endTime));
             }
 
             // Draw display times graph
@@ -65,13 +66,13 @@ namespace CapFrameX.Statistics.PlotBuilder
             // Draw PC latency graph
             if (plotSettings.ShowPcLatency)
             {
-                SetPcLatencyChart(plotModel, session.GetPcLatencyPointTimeWindow());
+                SetPcLatencyChart(plotModel, GetRenderablePoints(session.GetPcLatencyPointTimeWindow(), startTime, endTime));
             }
 
             // Draw Animation Error graph
             if (plotSettings.ShowAnimationError)
             {
-                SetAnimationErrorChart(plotModel, session.GetAnimationErrorPointTimeWindow());
+                SetAnimationErrorChart(plotModel, GetRenderablePoints(session.GetAnimationErrorPointTimeWindow(), startTime, endTime));
             }
 
             SetAggregationSeparators(session, plotModel, plotSettings.ShowAggregationSeparators);
@@ -85,30 +86,14 @@ namespace CapFrameX.Statistics.PlotBuilder
         {
             if (frametimePoints == null || !frametimePoints.Any()) return;
 
-            int count = frametimePoints.Count;
-            var frametimeDataPoints = frametimePoints.Select(pnt => new DataPoint(pnt.X, pnt.Y));
-            var GpuActiveTimeDataPoints = GpuActiveTimePoints.Select(pnt => new DataPoint(pnt.X, pnt.Y));
-            var CpuActiveTimeDataPoints = CpuActiveTimePoints.Select(pnt => new DataPoint(pnt.X, pnt.Y));
-
-            IList<double> movingAverageValues;
-
-            if (plotSettings.ShowDisplayTimes)
-            {
-                movingAverageValues = _frametimesStatisticProvider.GetMovingAverage(displaytimespoints.Select(pnt => pnt.Y).ToList());
-            }
-            else
-            {
-                movingAverageValues = _frametimesStatisticProvider.GetMovingAverage(frametimePoints.Select(pnt => pnt.Y).ToList());
-            }
-
-            var stuttering = new List<double>();
-            var lowFPS = new List<double>();
-
-            for (int i = 0; i < count; i++)
-            {
-                stuttering.Add(movingAverageValues[i] * plotSettings.StutteringFactor);
-                lowFPS.Add(1000 / plotSettings.LowFPSThreshold);
-            }
+            var movingAverageSourcePoints = plotSettings.ShowDisplayTimes && displaytimespoints.Any()
+                ? displaytimespoints
+                : frametimePoints;
+            var movingAverageValues = _frametimesStatisticProvider.GetMovingAverage(
+                movingAverageSourcePoints.Select(point => point.Y).ToList());
+            var movingAveragePoints = movingAverageValues
+                .Select((value, index) => new Point(movingAverageSourcePoints[index].X, value))
+                .ToList();
 
             plotModel.Series.Clear();
 
@@ -168,20 +153,24 @@ namespace CapFrameX.Statistics.PlotBuilder
                 EdgeRenderingMode = EdgeRenderingMode.PreferSpeed
             };
 
-            frametimeSeries.Points.AddRange(frametimeDataPoints);
-            movingAverageSeries.Points.AddRange(movingAverageValues.Select((y, i) => new DataPoint(frametimePoints[i].X, y)));
+            frametimeSeries.Points.AddRange(GetRenderablePoints(frametimePoints)
+                .Select(point => new DataPoint(point.X, point.Y)));
+            movingAverageSeries.Points.AddRange(GetRenderablePoints(movingAveragePoints)
+                .Select(point => new DataPoint(point.X, point.Y)));
 
             if (plotSettings.ShowGpuActiveCharts)
-                GpuActiveTimeSeries.Points.AddRange(GpuActiveTimeDataPoints);
+                GpuActiveTimeSeries.Points.AddRange(GetRenderablePoints(GpuActiveTimePoints)
+                    .Select(point => new DataPoint(point.X, point.Y)));
 
             if (plotSettings.ShowCpuActiveCharts)
-                CpuActiveTimeSeries.Points.AddRange(CpuActiveTimeDataPoints);
+                CpuActiveTimeSeries.Points.AddRange(GetRenderablePoints(CpuActiveTimePoints)
+                    .Select(point => new DataPoint(point.X, point.Y)));
 
             UpdateAxis(EPlotAxis.XAXIS, (axis) =>
             {
                 axis.Minimum = frametimePoints.First().X;
                 axis.Maximum = frametimePoints.Last().X;
-            });
+            }, false);
 
             plotModel.Series.Add(frametimeSeries);
             plotModel.Series.Add(movingAverageSeries);
@@ -194,14 +183,19 @@ namespace CapFrameX.Statistics.PlotBuilder
 
             if (plotSettings.ShowThresholds)
             {
-                stutteringSeries.Points.AddRange(stuttering.Select((y, i) => new DataPoint(frametimePoints[i].X, y)));
-                lowFPSSeries.Points.AddRange(lowFPS.Select((y, i) => new DataPoint(frametimePoints[i].X, y)));
+                var stutteringPoints = movingAveragePoints
+                    .Select(point => new Point(point.X, point.Y * plotSettings.StutteringFactor))
+                    .ToList();
+                stutteringSeries.Points.AddRange(GetRenderablePoints(stutteringPoints)
+                    .Select(point => new DataPoint(point.X, point.Y)));
+
+                double lowFpsThreshold = 1000 / plotSettings.LowFPSThreshold;
+                lowFPSSeries.Points.Add(new DataPoint(movingAverageSourcePoints.First().X, lowFpsThreshold));
+                lowFPSSeries.Points.Add(new DataPoint(movingAverageSourcePoints.Last().X, lowFpsThreshold));
 
                 plotModel.Series.Add(stutteringSeries);
                 plotModel.Series.Add(lowFPSSeries);
             }
-
-            plotModel.InvalidatePlot(true);
         }
     }
 }

--- a/source/CapFrameX.Statistics.PlotBuilder/LineSeries.cs
+++ b/source/CapFrameX.Statistics.PlotBuilder/LineSeries.cs
@@ -1,10 +1,93 @@
 ﻿using OxyPlot;
 
+using System;
+using System.Collections.Generic;
+
 namespace CapFrameX.Statistics.PlotBuilder
 {
     public class LineSeries: OxyPlot.Series.LineSeries
 	{
 		public int LegendStrokeThickness { get; set; }
+
+        public LineSeries()
+        {
+            // Decimate after transformation to screen space. Raw samples remain in
+            // the series so zooming and the tracker retain their full precision.
+            Decimator = DecimateScreenPoints;
+            MinimumSegmentLength = 0;
+        }
+
+        public static void DecimateScreenPoints(List<ScreenPoint> input, List<ScreenPoint> output)
+        {
+            if (input == null || input.Count == 0)
+                return;
+
+            if (input.Count <= 2)
+            {
+                output.AddRange(input);
+                return;
+            }
+
+            AddDistinct(output, input[0]);
+            int index = 1;
+            int lastIndex = input.Count - 1;
+
+            while (index < lastIndex)
+            {
+                int pixelColumn = GetPixelColumn(input[index].X);
+                int minimumIndex = index;
+                int maximumIndex = index;
+                int groupEnd = index + 1;
+
+                while (groupEnd < lastIndex && GetPixelColumn(input[groupEnd].X) == pixelColumn)
+                {
+                    if (input[groupEnd].Y < input[minimumIndex].Y)
+                        minimumIndex = groupEnd;
+
+                    if (input[groupEnd].Y > input[maximumIndex].Y)
+                        maximumIndex = groupEnd;
+
+                    groupEnd++;
+                }
+
+                if (minimumIndex <= maximumIndex)
+                {
+                    AddDistinct(output, input[minimumIndex]);
+                    AddDistinct(output, input[maximumIndex]);
+                }
+                else
+                {
+                    AddDistinct(output, input[maximumIndex]);
+                    AddDistinct(output, input[minimumIndex]);
+                }
+
+                index = groupEnd;
+            }
+
+            AddDistinct(output, input[lastIndex]);
+        }
+
+        private static int GetPixelColumn(double x)
+        {
+            if (double.IsNaN(x))
+                return int.MinValue;
+            if (x <= int.MinValue)
+                return int.MinValue;
+            if (x >= int.MaxValue)
+                return int.MaxValue;
+
+            return (int)Math.Floor(x);
+        }
+
+        private static void AddDistinct(IList<ScreenPoint> output, ScreenPoint point)
+        {
+            if (output.Count == 0
+                || output[output.Count - 1].X != point.X
+                || output[output.Count - 1].Y != point.Y)
+            {
+                output.Add(point);
+            }
+        }
 
         public override void RenderLegend(IRenderContext rc, OxyRect legendBox)
         {

--- a/source/CapFrameX.Statistics.PlotBuilder/PlotBuilder.cs
+++ b/source/CapFrameX.Statistics.PlotBuilder/PlotBuilder.cs
@@ -196,20 +196,26 @@ namespace CapFrameX.Statistics.PlotBuilder
             }
         };
 
-        public void Reset()
+        public void Reset(bool invalidatePlot = true)
         {
             PlotModel.Series.Clear();
             PlotModel.Axes.Clear();
-            PlotModel.InvalidatePlot(true);
+            if (invalidatePlot)
+            {
+                PlotModel.InvalidatePlot(true);
+            }
         }
 
-        public void UpdateAxis(EPlotAxis axisType, Action<Axis> action)
+        public void UpdateAxis(EPlotAxis axisType, Action<Axis> action, bool invalidatePlot = true)
         {
             var axis = PlotModel.GetAxisOrDefault(axisType.GetDescription(), null);
             if (axis != null)
             {
                 action(axis);
-                PlotModel.InvalidatePlot(false);
+                if (invalidatePlot)
+                {
+                    PlotModel.InvalidatePlot(false);
+                }
             }
         }
 
@@ -238,7 +244,7 @@ namespace CapFrameX.Statistics.PlotBuilder
                 YAxisKey = EPlotAxis.YAXISFRAMETIMES.GetDescription()
             };
 
-            series.Points.AddRange(points.Select(p => new DataPoint(p.X, p.Y)));
+            series.Points.AddRange(GetRenderablePoints(points).Select(p => new DataPoint(p.X, p.Y)));
             plotModel.Series.Add(series);
         }
 
@@ -253,7 +259,7 @@ namespace CapFrameX.Statistics.PlotBuilder
                 YAxisKey = EPlotAxis.YAXISPERCENTAGE.GetDescription()
             };
 
-            series.Points.AddRange(points.Select(p => new DataPoint(p.X, p.Y)));
+            series.Points.AddRange(GetRenderablePoints(points).Select(p => new DataPoint(p.X, p.Y)));
             plotModel.Series.Add(series);
         }
 
@@ -268,7 +274,7 @@ namespace CapFrameX.Statistics.PlotBuilder
                 YAxisKey = EPlotAxis.YAXISPERCENTAGE.GetDescription()
             };
 
-            series.Points.AddRange(points.Select(p => new DataPoint(p.X, p.Y)));
+            series.Points.AddRange(GetRenderablePoints(points).Select(p => new DataPoint(p.X, p.Y)));
             plotModel.Series.Add(series);
         }
 
@@ -283,7 +289,7 @@ namespace CapFrameX.Statistics.PlotBuilder
                 YAxisKey = EPlotAxis.YAXISPERCENTAGE.GetDescription()
             };
 
-            series.Points.AddRange(points.Select(p => new DataPoint(p.X, p.Y)));
+            series.Points.AddRange(GetRenderablePoints(points).Select(p => new DataPoint(p.X, p.Y)));
             plotModel.Series.Add(series);
         }
 
@@ -299,7 +305,7 @@ namespace CapFrameX.Statistics.PlotBuilder
                 YAxisKey = EPlotAxis.YAXISPERCENTAGE.GetDescription()
             };
 
-            series.Points.AddRange(points.Select(p => new DataPoint(p.X, p.Y)));
+            series.Points.AddRange(GetRenderablePoints(points).Select(p => new DataPoint(p.X, p.Y)));
             plotModel.Series.Add(series);
         }
 
@@ -314,7 +320,7 @@ namespace CapFrameX.Statistics.PlotBuilder
                 YAxisKey = EPlotAxis.YAXISFRAMETIMES.GetDescription()
             };
 
-            series.Points.AddRange(points.Select(p => new DataPoint(p.X, p.Y)));
+            series.Points.AddRange(GetRenderablePoints(points).Select(p => new DataPoint(p.X, p.Y)));
             plotModel.Series.Add(series);
         }
 
@@ -354,8 +360,35 @@ namespace CapFrameX.Statistics.PlotBuilder
                 YAxisKey = EPlotAxis.YAXISFRAMETIMES.GetDescription()
             };
 
-            series.Points.AddRange(points.Select(p => new DataPoint(p.X, p.Y)));
+            series.Points.AddRange(GetRenderablePoints(points).Select(p => new DataPoint(p.X, p.Y)));
             plotModel.Series.Add(series);
+        }
+
+        protected static IList<Point> GetRenderablePoints(IList<Point> points)
+        {
+            return points ?? new List<Point>();
+        }
+
+        protected static IList<Point> GetRenderablePoints(IList<Point> points, double startTime, double endTime)
+        {
+            if (points == null || points.Count == 0)
+            {
+                return new List<Point>();
+            }
+
+            var window = new List<Point>(points.Count);
+            for (int i = 0; i < points.Count; i++)
+            {
+                Point point = points[i];
+                if (point.X >= startTime && point.X <= endTime
+                    && !double.IsNaN(point.X) && !double.IsInfinity(point.X)
+                    && !double.IsNaN(point.Y) && !double.IsInfinity(point.Y))
+                {
+                    window.Add(point);
+                }
+            }
+
+            return window;
         }
 
         public void SetAggregationSeparators(ISession session, PlotModel plotModel, bool showSeparators)

--- a/source/CapFrameX.Test/CapFrameX.Test.csproj
+++ b/source/CapFrameX.Test/CapFrameX.Test.csproj
@@ -76,8 +76,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Data\CaptureManagerTest.cs" />
+    <Compile Include="Data\LocalRecordDataServerTest.cs" />
     <Compile Include="Integration\PresentMonIntegrationTest.cs" />
     <Compile Include="Data\FileRecordInfoTest.cs" />
+    <Compile Include="Data\RecordManagerCacheTest.cs" />
     <Compile Include="Extensions\ObservableExtensionsTest.cs" />
     <Compile Include="Extensions\StringExtensionsTest.cs" />
     <Compile Include="Mocks\MockBenchlabService.cs" />
@@ -97,9 +99,13 @@
     <Compile Include="Sensor\PantherLakeVoltageTest.cs" />
     <Compile Include="Statistics\CircularBufferTest.cs" />
     <Compile Include="Statistics\FrametimeStatisticProviderTest.cs" />
+    <Compile Include="Statistics\LineSeriesTest.cs" />
+    <Compile Include="Statistics\SessionExtensionsTest.cs" />
     <Compile Include="TestHelper.cs" />
     <Compile Include="Updater\UpdateCheckTest.cs" />
     <Compile Include="ViewModel\CaptureViewModelTest.cs" />
+    <Compile Include="ViewModel\ComparisonMetricSourceResolverTest.cs" />
+    <Compile Include="ViewModel\FpsGraphDataContextTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestRecordFiles\CustomFilenameWithoutComment.csv">
@@ -184,6 +190,10 @@
     <ProjectReference Include="..\CapFrameX.Statistics.NetStandard\CapFrameX.Statistics.NetStandard.csproj">
       <Project>{dc30f7f7-5725-4de9-b271-0d621b559cd5}</Project>
       <Name>CapFrameX.Statistics.NetStandard</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\CapFrameX.Statistics.PlotBuilder\CapFrameX.Statistics.PlotBuilder.csproj">
+      <Project>{80a26f08-6ae5-472d-bb13-b6fb9a37fdcb}</Project>
+      <Name>CapFrameX.Statistics.PlotBuilder</Name>
     </ProjectReference>
     <ProjectReference Include="..\CapFrameX.Updater\CapFrameX.Updater.csproj">
       <Project>{5d12aa37-cc30-4476-94ad-11c15dc65518}</Project>

--- a/source/CapFrameX.Test/Data/LocalRecordDataServerTest.cs
+++ b/source/CapFrameX.Test/Data/LocalRecordDataServerTest.cs
@@ -1,0 +1,48 @@
+using CapFrameX.Contracts.Configuration;
+using CapFrameX.Data;
+using CapFrameX.Data.Session.Classes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Linq;
+
+namespace CapFrameX.Test.Data
+{
+    [TestClass]
+    public class LocalRecordDataServerTest
+    {
+        [TestMethod]
+        public void DerivedWindowCache_ReusesResultsAndInvalidatesDisplayMetricMode()
+        {
+            var configuration = new Mock<IAppConfiguration>();
+            configuration.SetupProperty(value => value.UseDisplayChangeMetrics, false);
+            configuration.Setup(value => value.FpsValuesRoundingDigits).Returns(2);
+            configuration.Setup(value => value.IntervalAverageWindowTime).Returns(500);
+
+            var captureData = new SessionCaptureData(2)
+            {
+                TimeInSeconds = new[] { 0d, 1d },
+                MsBetweenPresents = new[] { 10d, 20d },
+                MsBetweenDisplayChange = new[] { 5d, 10d }
+            };
+            var session = new Session();
+            session.Runs.Add(new SessionRun { CaptureData = captureData });
+            var server = new LocalRecordDataServer(configuration.Object)
+            {
+                CurrentSession = session
+            };
+            server.SetTimeWindow(0, 1);
+
+            var presentFps = server.GetFpsTimeWindow();
+            var repeatedPresentFps = server.GetFpsTimeWindow();
+
+            Assert.AreSame(presentFps, repeatedPresentFps);
+            CollectionAssert.AreEqual(new[] { 100d, 50d }, presentFps.ToArray());
+
+            configuration.Object.UseDisplayChangeMetrics = true;
+            var displayFps = server.GetFpsTimeWindow();
+
+            Assert.AreNotSame(presentFps, displayFps);
+            CollectionAssert.AreEqual(new[] { 200d, 100d }, displayFps.ToArray());
+        }
+    }
+}

--- a/source/CapFrameX.Test/Data/RecordManagerCacheTest.cs
+++ b/source/CapFrameX.Test/Data/RecordManagerCacheTest.cs
@@ -1,0 +1,391 @@
+using CapFrameX.Data;
+using CapFrameX.Data.Session.Contracts;
+using CapFrameX.Configuration;
+using CapFrameX.Contracts.Configuration;
+using CapFrameX.Contracts.Data;
+using CapFrameX.Extensions;
+using CapFrameX.Test.Mocks;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Prism.Events;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CapFrameX.Test.Data
+{
+    [TestClass]
+    public class RecordManagerCacheTest
+    {
+        private string _testDirectory;
+        private RecordManager _recordManager;
+        private IPathService _previousPathService;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _testDirectory = Path.Combine(Path.GetTempPath(), "CapFrameX.RecordCacheTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_testDirectory);
+            _previousPathService = PathServiceProvider.PathService;
+            var pathService = new Mock<IPathService>();
+            pathService.SetupGet(service => service.ConfigFolder).Returns(Path.Combine(_testDirectory, "Config"));
+            PathServiceProvider.PathService = pathService.Object;
+            _recordManager = CreateRecordManager();
+        }
+
+        private static RecordManager CreateRecordManager(ProcessList processList = null)
+        {
+            return new RecordManager(
+                new Mock<ILogger<RecordManager>>().Object,
+                null,
+                null,
+                null,
+                null,
+                null,
+                processList,
+                null,
+                new EventAggregator(),
+                null);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            // Allow the bounded background writer to finish before removing its isolated folder.
+            Thread.Sleep(400);
+            PathServiceProvider.PathService = _previousPathService;
+            if (Directory.Exists(_testDirectory))
+            {
+                Directory.Delete(_testDirectory, true);
+            }
+        }
+
+        [TestMethod]
+        public void LoadData_UnchangedNormalizedPath_ReusesSession()
+        {
+            string path = CreateSessionFile("capture.json", "First.exe");
+            string equivalentPath = Path.Combine(_testDirectory, ".", "capture.json");
+
+            ISession first = _recordManager.LoadData(path);
+            ISession second = _recordManager.LoadData(equivalentPath);
+
+            Assert.IsNotNull(first);
+            Assert.AreSame(first, second);
+        }
+
+        [TestMethod]
+        public void LoadData_ChangedFileStamp_ReloadsSession()
+        {
+            string path = CreateSessionFile("capture.json", "First.exe");
+            ISession first = _recordManager.LoadData(path);
+
+            DateTime changedStamp = File.GetLastWriteTimeUtc(path).AddSeconds(2);
+            File.WriteAllText(path, CreateSessionJson("Other.exe"));
+            File.SetLastWriteTimeUtc(path, changedStamp);
+
+            ISession second = _recordManager.LoadData(path);
+
+            Assert.IsNotNull(first);
+            Assert.IsNotNull(second);
+            Assert.AreNotSame(first, second);
+            Assert.AreEqual("Other.exe", second.Info.ProcessName);
+        }
+
+        [TestMethod]
+        public async Task LoadData_ConcurrentRequests_ShareSession()
+        {
+            string path = CreateSessionFile("capture.json", "First.exe");
+            var loads = Enumerable.Range(0, 12)
+                .Select(_ => Task.Run(() => _recordManager.LoadData(path)))
+                .ToArray();
+
+            ISession[] sessions = await Task.WhenAll(loads);
+
+            Assert.IsTrue(sessions.All(session => session != null));
+            Assert.IsTrue(sessions.All(session => ReferenceEquals(sessions[0], session)));
+        }
+
+        [TestMethod]
+        public void IncrementalPresentHash_MatchesLegacyContract()
+        {
+            var cases = new[]
+            {
+                new string[0],
+                new[] { "single" },
+                new[] { "first", "second", "third" },
+                new[] { "first", string.Empty, "third" },
+                new[] { "embedded,comma", "\u00e4\ud83d\ude80" }
+            };
+            var method = typeof(RecordManager).GetMethod("GetPresentLinesSha1",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.IsNotNull(method);
+            foreach (var lines in cases)
+            {
+                string expected = string.Join(",", lines).GetSha1();
+                string actual = (string)method.Invoke(null, new object[] { lines });
+                Assert.AreEqual(expected, actual);
+            }
+            Assert.AreEqual("DA39A3EE5E6B4B0D3255BFEF95601890AFD80709",
+                (string)method.Invoke(null, new object[] { new string[0] }));
+        }
+
+        [TestMethod]
+        public void ConvertPresentData_DominantSwapChain_PreservesSelectedRowsAndValues()
+        {
+            var recordManager = new RecordManager(
+                new Mock<ILogger<RecordManager>>().Object,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                new EventAggregator(),
+                new MockCaptureService());
+            const string header = "Application,ProcessID,SwapChainAddress,TimeInSeconds,MsBetweenPresents,MsBetweenDisplayChange";
+            var selectedRows = new[]
+            {
+                "P2,2,C,10.00,20,21",
+                "P2,2,C,10.02,22,23",
+                "P2,2,C,10.04,24,25",
+                "P2,2,C,10.06,26,27"
+            };
+            var lines = new List<string> { header };
+            lines.AddRange(new[]
+            {
+                "P1,1,A,1.00,10,11",
+                "P1,1,A,1.01,10,11",
+                "P1,1,A,1.02,10,11",
+                "P1,1,B,2.00,12,13",
+                "P1,1,B,2.01,12,13"
+            });
+            lines.AddRange(selectedRows);
+
+            var run = recordManager.ConvertPresentDataLinesToSessionRun(lines);
+
+            Assert.AreEqual(string.Join(",", selectedRows).GetSha1(), run.Hash);
+            CollectionAssert.AreEqual(new[] { 20d, 22d, 24d, 26d }, run.CaptureData.MsBetweenPresents);
+            CollectionAssert.AreEqual(new[] { 21d, 23d, 25d, 27d }, run.CaptureData.MsBetweenDisplayChange);
+            var expectedTimes = new[] { 0d, 0.02d, 0.04d, 0.06d };
+            for (int i = 0; i < expectedTimes.Length; i++)
+            {
+                Assert.AreEqual(expectedTimes[i], run.CaptureData.TimeInSeconds[i], 1E-12);
+            }
+            Assert.IsTrue(run.CaptureData.AnimationError.All(double.IsNaN));
+        }
+
+        [TestMethod]
+        public async Task GetFileRecordInfo_JsonMetadataScan_MatchesFullSessionAndCachesResult()
+        {
+            string path = Path.Combine(_testDirectory, "metadata.json");
+            File.WriteAllText(path,
+                "{\"Hash\":\"SESSION-HASH\",\"Info\":{" +
+                "\"Id\":\"8f9f8c95-f1c1-4a38-90b4-61c74a40df35\"," +
+                "\"CreationDate\":\"2026-07-18T12:00:00Z\",\"ProcessName\":\"Game.exe\"," +
+                "\"GameName\":\"Game Display\",\"Processor\":\"CPU\",\"GPU\":\"GPU\"," +
+                "\"SystemRam\":\"32 GB\",\"Comment\":\"metadata\"}," +
+                "\"Runs\":[" +
+                "{\"CaptureData\":{\"TimeInSeconds\":[0.0,1.25],\"MsBetweenPresents\":[16.0,17.0]}}," +
+                "{\"CaptureData\":{\"TimeInSeconds\":[1.25,2.75],\"MsBetweenPresents\":[18.0,19.0]}}]}");
+            var fileInfo = new FileInfo(path);
+
+            var lightweight = await _recordManager.GetFileRecordInfo(fileInfo);
+            var cached = await _recordManager.GetFileRecordInfo(new FileInfo(path));
+            var fullSession = _recordManager.LoadData(path);
+            var full = FileRecordInfo.Create(fileInfo, fullSession);
+
+            Assert.IsNotNull(lightweight);
+            Assert.AreSame(lightweight, cached);
+            Assert.AreEqual(full.Hash, lightweight.Hash);
+            Assert.AreEqual(full.Id, lightweight.Id);
+            Assert.AreEqual(full.ProcessName, lightweight.ProcessName);
+            Assert.AreEqual(full.GameName, lightweight.GameName);
+            Assert.AreEqual(full.ProcessorName, lightweight.ProcessorName);
+            Assert.AreEqual(full.GraphicCardName, lightweight.GraphicCardName);
+            Assert.AreEqual(full.SystemRamInfo, lightweight.SystemRamInfo);
+            Assert.AreEqual(full.Comment, lightweight.Comment);
+            Assert.AreEqual(full.IsAggregated, lightweight.IsAggregated);
+            Assert.AreEqual(2.75, lightweight.RecordTime, 1E-12);
+        }
+
+        [TestMethod]
+        public async Task GetFileRecordInfo_PersistentIndex_ReusesMetadataWithoutOpeningCapture()
+        {
+            string path = CreateMetadataSessionFile("persistent.json", "Persistent.exe", "Persistent Game");
+            var first = await _recordManager.GetFileRecordInfo(new FileInfo(path));
+            string indexPath = await WaitForRecordIndexAsync();
+
+            var secondManager = CreateRecordManager();
+            IFileRecordInfo cached;
+            using (new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                cached = await secondManager.GetFileRecordInfo(new FileInfo(path));
+            }
+
+            Assert.IsTrue(File.Exists(indexPath));
+            Assert.IsNotNull(cached);
+            Assert.AreEqual(first.Hash, cached.Hash);
+            Assert.AreEqual(first.ProcessName, cached.ProcessName);
+            Assert.AreEqual(first.GameName, cached.GameName);
+            Assert.AreEqual(first.RecordTime, cached.RecordTime, 1E-12);
+        }
+
+        [TestMethod]
+        public async Task GetFileRecordInfo_CorruptPersistentIndex_FallsBackAndRepairs()
+        {
+            string cacheDirectory = Path.Combine(_testDirectory, "Config", "Cache");
+            Directory.CreateDirectory(cacheDirectory);
+            string indexPath = Path.Combine(cacheDirectory, "RecordMetadataIndex.bin");
+            File.WriteAllBytes(indexPath, new byte[] { 1, 2, 3, 4, 5 });
+            string path = CreateMetadataSessionFile("corrupt-index.json", "Fallback.exe", "Fallback Game");
+
+            var recordInfo = await _recordManager.GetFileRecordInfo(new FileInfo(path));
+            await WaitForRecordIndexAsync();
+
+            Assert.IsNotNull(recordInfo);
+            Assert.AreEqual("Fallback.exe", recordInfo.ProcessName);
+            byte[] header = File.ReadAllBytes(indexPath).Take(4).ToArray();
+            CollectionAssert.AreEqual(new byte[] { 0x43, 0x46, 0x49, 0x58 }, header);
+        }
+
+        [TestMethod]
+        public async Task GetFileRecordInfo_PersistentIndex_FileChanged_ReloadsMetadata()
+        {
+            string path = CreateMetadataSessionFile("changed.json", "Before.exe", "Before Game");
+            await _recordManager.GetFileRecordInfo(new FileInfo(path));
+            await WaitForRecordIndexAsync();
+            DateTime changedStamp = File.GetLastWriteTimeUtc(path).AddSeconds(2);
+
+            CreateMetadataSessionFile("changed.json", "Afterx.exe", "Afterx Game");
+            File.SetLastWriteTimeUtc(path, changedStamp);
+            var secondManager = CreateRecordManager();
+            var refreshed = await secondManager.GetFileRecordInfo(new FileInfo(path));
+
+            Assert.IsNotNull(refreshed);
+            Assert.AreEqual("Afterx.exe", refreshed.ProcessName);
+            Assert.AreEqual("Afterx Game", refreshed.GameName);
+        }
+
+        [TestMethod]
+        public async Task GetFileRecordInfo_ProcessListNameChanged_RefreshesMemoryAndPersistentCaches()
+        {
+            var processList = (ProcessList)Activator.CreateInstance(typeof(ProcessList),
+                BindingFlags.Instance | BindingFlags.NonPublic, null,
+                new object[]
+                {
+                    Path.Combine(_testDirectory, "processes.json"),
+                    new Mock<IAppConfiguration>().Object,
+                    new Mock<ILogger<ProcessList>>().Object
+                }, null);
+            processList.AddEntry("RenameMe.exe", "First Name");
+            var manager = CreateRecordManager(processList);
+            string path = CreateMetadataSessionFile("rename.json", "RenameMe.exe", "RenameMe.exe");
+
+            var first = await manager.GetFileRecordInfo(new FileInfo(path));
+            Assert.AreEqual("First Name", first.GameName);
+            await WaitForRecordIndexAsync();
+
+            processList.FindProcessByName("RenameMe.exe").UpdateDisplayName("Second Name");
+            var memoryCached = await manager.GetFileRecordInfo(new FileInfo(path));
+            var persistentCached = await CreateRecordManager(processList)
+                .GetFileRecordInfo(new FileInfo(path));
+
+            Assert.AreEqual("Second Name", memoryCached.GameName);
+            Assert.AreEqual("Second Name", persistentCached.GameName);
+        }
+
+        [TestMethod]
+        public async Task GetFileRecordInfo_IncompleteJsonMetadata_ReturnsNull()
+        {
+            string infoOnlyPath = Path.Combine(_testDirectory, "info-only.json");
+            string runsOnlyPath = Path.Combine(_testDirectory, "runs-only.json");
+            File.WriteAllText(infoOnlyPath,
+                "{\"Hash\":\"hash\",\"Info\":{\"ProcessName\":\"MissingRuns.exe\"}}");
+            File.WriteAllText(runsOnlyPath,
+                "{\"Hash\":\"hash\",\"Runs\":[{\"CaptureData\":{\"TimeInSeconds\":[0,1]}}]}");
+
+            var infoOnly = await _recordManager.GetFileRecordInfo(new FileInfo(infoOnlyPath));
+            var runsOnly = await _recordManager.GetFileRecordInfo(new FileInfo(runsOnlyPath));
+
+            Assert.IsNull(infoOnly);
+            Assert.IsNull(runsOnly);
+        }
+
+        [TestMethod]
+        public void ConvertPresentData_QuotedCsvFields_FilterAndParseCorrectly()
+        {
+            var recordManager = new RecordManager(
+                new Mock<ILogger<RecordManager>>().Object,
+                null, null, null, null, null, null, null,
+                new EventAggregator(), new MockCaptureService());
+            const string header = "Application,ProcessID,SwapChainAddress,TimeInSeconds,MsBetweenPresents,MsBetweenDisplayChange";
+            var selectedRows = new[]
+            {
+                "\"P,One\",1,\"A,1\",\"10.00\",\"20\",\"21\"",
+                "\"P,One\",1,\"A,1\",\"10.02\",\"22\",\"23\""
+            };
+            var lines = new List<string>
+            {
+                header,
+                "\"Other\",2,\"B\",1.0,11,12"
+            };
+            lines.AddRange(selectedRows);
+
+            var run = recordManager.ConvertPresentDataLinesToSessionRun(lines);
+
+            Assert.AreEqual(string.Join(",", selectedRows).GetSha1(), run.Hash);
+            CollectionAssert.AreEqual(new[] { 20d, 22d }, run.CaptureData.MsBetweenPresents);
+            CollectionAssert.AreEqual(new[] { 21d, 23d }, run.CaptureData.MsBetweenDisplayChange);
+            Assert.AreEqual(0d, run.CaptureData.TimeInSeconds[0], 1E-12);
+            Assert.AreEqual(0.02d, run.CaptureData.TimeInSeconds[1], 1E-12);
+        }
+
+        private string CreateSessionFile(string fileName, string processName)
+        {
+            string path = Path.Combine(_testDirectory, fileName);
+            File.WriteAllText(path, CreateSessionJson(processName));
+            return path;
+        }
+
+        private static string CreateSessionJson(string processName)
+        {
+            return "{\"Hash\":\"hash\",\"Info\":{\"ProcessName\":\"" + processName + "\"},\"Runs\":[]}";
+        }
+
+        private string CreateMetadataSessionFile(string fileName, string processName, string gameName)
+        {
+            string path = Path.Combine(_testDirectory, fileName);
+            File.WriteAllText(path,
+                "{\"Hash\":\"persistent-hash\",\"Info\":{" +
+                "\"Id\":\"8f9f8c95-f1c1-4a38-90b4-61c74a40df35\"," +
+                "\"CreationDate\":\"2026-07-18T12:00:00Z\"," +
+                "\"ProcessName\":\"" + processName + "\"," +
+                "\"GameName\":\"" + gameName + "\",\"Comment\":\"indexed\"}," +
+                "\"Runs\":[{\"CaptureData\":{\"TimeInSeconds\":[0.0,2.5]}}]}");
+            return path;
+        }
+
+        private async Task<string> WaitForRecordIndexAsync()
+        {
+            string indexPath = Path.Combine(_testDirectory, "Config", "Cache", "RecordMetadataIndex.bin");
+            for (int attempt = 0; attempt < 40; attempt++)
+            {
+                if (File.Exists(indexPath) && new FileInfo(indexPath).Length > 12)
+                {
+                    return indexPath;
+                }
+                await Task.Delay(50);
+            }
+
+            Assert.Fail("The persistent record metadata index was not written.");
+            return indexPath;
+        }
+    }
+}

--- a/source/CapFrameX.Test/Statistics/FrametimeStatisticProviderTest.cs
+++ b/source/CapFrameX.Test/Statistics/FrametimeStatisticProviderTest.cs
@@ -298,6 +298,51 @@ namespace CapFrameX.Test.Statistics
             Assert.IsFalse(result.Contains(10000));
         }
 
+        [TestMethod]
+        public void GetOutlierAdjustedSequence_DeciPercentile_RetainsConstantSequence()
+        {
+            var sequence = Enumerable.Repeat(16.67, 1000).ToList();
+
+            var result = _provider.GetOutlierAdjustedSequence(sequence, ERemoveOutlierMethod.DeciPercentile);
+
+            Assert.AreEqual(sequence.Count, result.Count);
+            CollectionAssert.AreEqual(sequence, result.ToList());
+        }
+
+        [TestMethod]
+        public void GetOutlierAdjustedSequence_DeciPercentile_ExactThousandSamples_RemovesExactlyOne()
+        {
+            // Regression: 1000 * (1 - 0.999) evaluates to 1.0000000000000002 in
+            // floating point, so an unguarded Math.Ceiling removed two samples.
+            var sequence = Enumerable.Repeat(10.0, 999).Concat(new[] { 500.0 }).ToList();
+
+            var result = _provider.GetOutlierAdjustedSequence(sequence, ERemoveOutlierMethod.DeciPercentile);
+
+            Assert.AreEqual(999, result.Count);
+            Assert.IsFalse(result.Contains(500.0));
+        }
+
+        [TestMethod]
+        public void GetOutlierAdjustedSequence_UnimplementedMethods_ReturnSequenceUnchanged()
+        {
+            // Regression: these enum members produced a null return value, which
+            // callers in SessionExtensions no longer null-coalesce.
+            var sequence = new List<double> { 10, 20, 30 };
+
+            foreach (var method in new[]
+            {
+                ERemoveOutlierMethod.InterquartileRange,
+                ERemoveOutlierMethod.ThreeSigma,
+                ERemoveOutlierMethod.TwoDotFiveSigma
+            })
+            {
+                var result = _provider.GetOutlierAdjustedSequence(sequence, method);
+
+                Assert.IsNotNull(result, $"Null returned for {method}");
+                CollectionAssert.AreEqual(sequence.ToList(), result.ToList(), $"Sequence changed for {method}");
+            }
+        }
+
         #endregion
 
         #region GetFpsThresholdCounts Tests
@@ -360,6 +405,128 @@ namespace CapFrameX.Test.Statistics
             var result = _provider.GetPercentageHighIntegralSequence(sequence, 0.99);
 
             Assert.IsFalse(double.IsNaN(result));
+        }
+
+        [TestMethod]
+        public void GetFpsMetricValues_MatchesIndividualMetricCalculations()
+        {
+            var sequence = Enumerable.Range(0, 5000)
+                .Select(index => 5.0 + index % 300 / 10.0)
+                .ToList();
+            var metrics = new[]
+            {
+                EMetric.Max, EMetric.P99, EMetric.P95, EMetric.Average, EMetric.Median,
+                EMetric.P5, EMetric.P1, EMetric.P0dot2, EMetric.P0dot1,
+                EMetric.OnePercentLowAverage, EMetric.ZerodotOnePercentLowAverage,
+                EMetric.OnePercentLowIntegral, EMetric.ZerodotOnePercentLowIntegral, EMetric.Min
+            };
+
+            var batch = _provider.GetFpsMetricValues(sequence, metrics);
+
+            foreach (var metric in metrics)
+            {
+                Assert.AreEqual(_provider.GetFpsMetricValue(sequence, metric), batch[metric], 0.001,
+                    $"Batch result differs for {metric}");
+            }
+        }
+
+        [TestMethod]
+        public void GetMetricAnalysis_FrametimeMetrics_MatchesIndividualCalculations()
+        {
+            var frametimes = Enumerable.Range(0, 10000)
+                .Select(index => 4.0 + index % 600 / 20.0)
+                .ToList();
+
+            var analysis = _provider.GetMetricAnalysis(frametimes, Array.Empty<double>(), false,
+                EMetric.P1.ToString(), EMetric.P0dot1.ToString());
+
+            Assert.AreEqual(_provider.GetFpsMetricValue(frametimes, EMetric.Average), analysis.Average, 0.001);
+            Assert.AreEqual(_provider.GetFpsMetricValue(frametimes, EMetric.P1), analysis.Second, 0.001);
+            Assert.AreEqual(_provider.GetFpsMetricValue(frametimes, EMetric.P0dot1), analysis.Third, 0.001);
+        }
+
+        [TestMethod]
+        public void GetMetricAnalysis_DisplayMetrics_UsesDisplayTimesOnlyForLowMetrics()
+        {
+            var frametimes = Enumerable.Range(0, 10000)
+                .Select(index => 5.0 + index % 500 / 25.0)
+                .ToList();
+            var displayTimes = Enumerable.Range(0, 10000)
+                .Select(index => 7.0 + index % 400 / 16.0)
+                .ToList();
+
+            var analysis = _provider.GetMetricAnalysis(frametimes, displayTimes, true,
+                EMetric.P1.ToString(), EMetric.P0dot1.ToString());
+
+            Assert.AreEqual(_provider.GetFpsMetricValue(frametimes, EMetric.Average), analysis.Average, 0.001);
+            Assert.AreEqual(_provider.GetFpsMetricValue(displayTimes, EMetric.P1), analysis.Second, 0.001);
+            Assert.AreEqual(_provider.GetFpsMetricValue(displayTimes, EMetric.P0dot1), analysis.Third, 0.001);
+        }
+
+        [TestMethod]
+        public void GetFrametimeMetricValues_MatchesIndividualMetricCalculations()
+        {
+            var sequence = Enumerable.Range(0, 5000)
+                .Select(index => 5.0 + index % 300 / 10.0)
+                .ToList();
+            var metrics = new[]
+            {
+                EMetric.Max, EMetric.P99, EMetric.P95, EMetric.Average, EMetric.Median,
+                EMetric.P5, EMetric.P1, EMetric.P0dot2, EMetric.P0dot1,
+                EMetric.OnePercentLowAverage, EMetric.ZerodotOnePercentLowAverage,
+                EMetric.OnePercentLowIntegral, EMetric.ZerodotOnePercentLowIntegral, EMetric.Min
+            };
+
+            var batch = _provider.GetFrametimeMetricValues(sequence, metrics);
+
+            foreach (var metric in metrics)
+            {
+                Assert.AreEqual(_provider.GetFrametimeMetricValue(sequence, metric), batch[metric], 0.001,
+                    $"Batch result differs for {metric}");
+            }
+        }
+
+        [TestMethod]
+        public void GetFrametimeMetricValues_RepeatedAnalysisInvalidatesAfterInPlaceMutation()
+        {
+            var sequence = Enumerable.Range(0, 5000)
+                .Select(index => 5.0 + index % 300 / 10.0)
+                .ToList();
+            var metrics = new[]
+            {
+                EMetric.Average, EMetric.P1, EMetric.P0dot1,
+                EMetric.OnePercentLowAverage, EMetric.ZerodotOnePercentLowAverage
+            };
+
+            _provider.GetFrametimeMetricValues(sequence, metrics);
+            sequence[2500] = 100000;
+
+            var cachedResult = _provider.GetFrametimeMetricValues(sequence, metrics);
+            var freshResult = _provider.GetFrametimeMetricValues(sequence.ToArray(), metrics);
+
+            foreach (var metric in metrics)
+            {
+                Assert.AreEqual(freshResult[metric], cachedResult[metric], 0.0,
+                    $"Cached result was stale for {metric}");
+            }
+        }
+
+        [TestMethod]
+        public void GetVariancePercentages_ClassifiesEachThresholdExactlyOnce()
+        {
+            var sequence = new List<double> { 0, 1, 4, 10, 20, 35 };
+
+            var result = _provider.GetVariancePercentages(sequence);
+
+            CollectionAssert.AreEqual(new[] { 0.2, 0.2, 0.2, 0.2, 0.2 }, result.ToArray());
+        }
+
+        [TestMethod]
+        public void GetVariancePercentages_NoValidPairs_ReturnsZeroes()
+        {
+            var result = _provider.GetVariancePercentages(new List<double> { 10, double.NaN, 11 });
+
+            CollectionAssert.AreEqual(new double[5], result.ToArray());
         }
 
         [TestMethod]

--- a/source/CapFrameX.Test/Statistics/LineSeriesTest.cs
+++ b/source/CapFrameX.Test/Statistics/LineSeriesTest.cs
@@ -1,0 +1,71 @@
+using CapFrameX.Data.Session.Classes;
+using CapFrameX.Statistics.NetStandard;
+using CapFrameX.Statistics.NetStandard.Contracts;
+using CapFrameX.Statistics.PlotBuilder;
+using CapFrameX.Statistics.PlotBuilder.Contracts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using OxyPlot;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CapFrameX.Test.Statistics
+{
+    [TestClass]
+    public class LineSeriesTest
+    {
+        [TestMethod]
+        public void DecimateScreenPoints_PreservesEndpointsAndPixelExtrema()
+        {
+            var input = new List<ScreenPoint>
+            {
+                new ScreenPoint(0.1, 5),
+                new ScreenPoint(0.2, 10),
+                new ScreenPoint(0.3, -20),
+                new ScreenPoint(0.4, 30),
+                new ScreenPoint(1.1, 8),
+                new ScreenPoint(1.2, -4),
+                new ScreenPoint(2.1, 7)
+            };
+            var output = new List<ScreenPoint>();
+
+            LineSeries.DecimateScreenPoints(input, output);
+
+            Assert.AreEqual(input.First(), output.First());
+            Assert.AreEqual(input.Last(), output.Last());
+            Assert.IsTrue(output.Contains(new ScreenPoint(0.3, -20)));
+            Assert.IsTrue(output.Contains(new ScreenPoint(0.4, 30)));
+            Assert.IsTrue(output.Contains(new ScreenPoint(1.2, -4)));
+            Assert.IsTrue(output.Count < input.Count);
+        }
+
+        [TestMethod]
+        public void FpsGraph_DisplayTimesUnavailable_FallsBackToPresentTimes()
+        {
+            var options = new Mock<IFrametimeStatisticProviderOptions>();
+            options.SetupGet(value => value.FpsValuesRoundingDigits).Returns(2);
+            options.SetupGet(value => value.IntervalAverageWindowTime).Returns(500);
+            var plotSettings = new Mock<IPlotSettings>();
+            plotSettings.SetupGet(value => value.ShowDisplayTimes).Returns(true);
+            var captureData = new SessionCaptureData(3)
+            {
+                TimeInSeconds = new[] { 0d, 1d, 2d },
+                MsBetweenPresents = new[] { 10d, 20d, 40d },
+                MsBetweenDisplayChange = new[] { 0d, 0d, 0d }
+            };
+            var session = new Session();
+            session.Runs.Add(new SessionRun { CaptureData = captureData });
+            var provider = new FrametimeStatisticProvider(options.Object);
+            var builder = new FpsGraphPlotBuilder(options.Object, provider);
+
+            builder.BuildPlotmodel(session, plotSettings.Object, 0, 2,
+                ERemoveOutlierMethod.None, EFilterMode.None);
+
+            var fpsSeries = builder.PlotModel.Series
+                .OfType<OxyPlot.Series.LineSeries>()
+                .Single(series => series.Title == "FPS");
+            Assert.AreEqual(3, fpsSeries.Points.Count);
+            Assert.AreEqual(100, fpsSeries.Points[0].Y, 0.001);
+        }
+    }
+}

--- a/source/CapFrameX.Test/Statistics/SessionExtensionsTest.cs
+++ b/source/CapFrameX.Test/Statistics/SessionExtensionsTest.cs
@@ -1,0 +1,251 @@
+using CapFrameX.Data.Session.Classes;
+using CapFrameX.Statistics.NetStandard;
+using CapFrameX.Statistics.NetStandard.Contracts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Linq;
+
+namespace CapFrameX.Test.Statistics
+{
+    [TestClass]
+    public class SessionExtensionsTest
+    {
+        private IFrametimeStatisticProviderOptions _options;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var optionsMock = new Mock<IFrametimeStatisticProviderOptions>();
+            optionsMock.Setup(options => options.FpsValuesRoundingDigits).Returns(2);
+            optionsMock.Setup(options => options.IntervalAverageWindowTime).Returns(500);
+            _options = optionsMock.Object;
+        }
+
+        [TestMethod]
+        public void GetFrametimePointsTimeWindow_OutlierRemovalPreservesTimestamps()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d, 3d, 4d },
+                new[] { 10d, 10000d, 20d, 30d, 40d });
+
+            var points = session.GetFrametimePointsTimeWindow(0, 4, _options,
+                ERemoveOutlierMethod.DeciPercentile);
+
+            CollectionAssert.AreEqual(new[] { 0d, 2d, 3d, 4d }, points.Select(point => point.X).ToArray());
+            CollectionAssert.AreEqual(new[] { 10d, 20d, 30d, 40d }, points.Select(point => point.Y).ToArray());
+        }
+
+        [TestMethod]
+        public void GetFrametimeTimeWindow_RejectsInvalidTimingSamples()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d, 3d, 4d, 5d },
+                new[] { 10d, 0d, double.NaN, double.PositiveInfinity, -1d, 20d });
+
+            var frametimes = session.GetFrametimeTimeWindow(0, 5, _options);
+
+            CollectionAssert.AreEqual(new[] { 10d, 20d }, frametimes.ToArray());
+        }
+
+        [TestMethod]
+        public void GetFrametimeDistributionPoints_IsTimeWeightedAndSumsToOneHundredPercent()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d },
+                new[] { 10.01d, 10.09d, 20d });
+
+            var distribution = session.GetFrametimeDistributionPoints(0, 2, _options);
+
+            Assert.AreEqual(2, distribution.Count);
+            Assert.AreEqual(100, distribution.Sum(point => point.Y), 0.000001);
+            Assert.AreEqual((10.01 + 10.09) / 40.1 * 100, distribution[0].Y, 0.000001);
+            Assert.AreEqual(20 / 40.1 * 100, distribution[1].Y, 0.000001);
+            Assert.AreEqual(20, distribution[1].X, 0.000001);
+        }
+
+        [TestMethod]
+        public void GetFrametimeDistributionPoints_UsesHalfOpenBins()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d },
+                new[] { 10d, 10.1d, 10.11d });
+
+            var distribution = session.GetFrametimeDistributionPoints(0, 2, _options);
+
+            CollectionAssert.AreEqual(new[] { 10.1d, 10.2d },
+                distribution.Select(point => point.X).ToArray());
+        }
+
+        [TestMethod]
+        public void GetFrametimeDistributionPoints_ExactMaximumBinEdge_UsesFinalInclusiveBin()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d },
+                new[] { 0.2d, 0.3d });
+
+            var distribution = session.GetFrametimeDistributionPoints(0, 1, _options);
+
+            Assert.AreEqual(1, distribution.Count);
+            Assert.AreEqual(0.3d, distribution[0].X, 0.000000001);
+            Assert.AreEqual(100d, distribution[0].Y, 0.000001);
+        }
+
+        [TestMethod]
+        public void GetActiveTimeWindows_PreserveZeroAndRejectInvalidSamples()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d, 3d },
+                new[] { 10d, 10d, 10d, 10d });
+            session.Runs[0].CaptureData.GpuActive = new[]
+                { 0d, -1d, double.NaN, 5d };
+            session.Runs[0].CaptureData.CpuActive = new[]
+                { 0d, double.PositiveInfinity, -2d, 4d };
+
+            var gpuValues = session.GetGpuActiveTimeTimeWindow(0, 3, _options);
+            var cpuPoints = session.GetCpuActiveTimePointsTimeWindow(0, 3, _options);
+
+            CollectionAssert.AreEqual(new[] { 0d, 5d }, gpuValues.ToArray());
+            CollectionAssert.AreEqual(new[] { 0d, 4d }, cpuPoints.Select(point => point.Y).ToArray());
+        }
+
+        [TestMethod]
+        public void GetDisplayTimeDistributionPoints_UsesDisplayChangeSamples()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d },
+                new[] { 10d, 10d, 10d });
+            session.Runs[0].CaptureData.MsBetweenDisplayChange = new[] { 5.01d, 5.09d, 30d };
+
+            var distribution = session.GetDisplayTimeDistributionPoints(0, 2, _options);
+
+            Assert.AreEqual(2, distribution.Count);
+            Assert.AreEqual((5.01 + 5.09) / 40.1 * 100, distribution[0].Y, 0.000001);
+            Assert.AreEqual(30 / 40.1 * 100, distribution[1].Y, 0.000001);
+        }
+
+        [TestMethod]
+        public void GetPcLatencyPointTimeWindow_DoesNotRequireSensorData()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d },
+                new[] { 10d, 10d });
+            session.Runs[0].CaptureData.PcLatency = new[] { 20d, 21d };
+
+            var points = session.GetPcLatencyPointTimeWindow();
+
+            CollectionAssert.AreEqual(new[] { 20d, 21d }, points.Select(point => point.Y).ToArray());
+        }
+
+        [TestMethod]
+        public void GetAnimationErrorTimeWindow_RejectsNonFiniteSamples()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d },
+                new[] { 10d, 10d, 10d });
+            session.Runs[0].CaptureData.AnimationError = new[]
+                { double.NaN, double.PositiveInfinity, -2d };
+
+            var values = session.GetAnimationErrorTimeWindow(0, 2);
+
+            CollectionAssert.AreEqual(new[] { -2d }, values.ToArray());
+        }
+
+        [TestMethod]
+        public void TimingCache_InvalidatesWhenCaptureArraysAreReplaced()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d },
+                new[] { 10d, 20d });
+
+            session.GetFrametimeTimeWindow(0, 1, _options);
+            session.Runs[0].CaptureData.TimeInSeconds = new[] { 5d, 6d };
+            session.Runs[0].CaptureData.MsBetweenPresents = new[] { 30d, 40d };
+
+            var values = session.GetFrametimeTimeWindow(5, 6, _options);
+
+            CollectionAssert.AreEqual(new[] { 30d, 40d }, values.ToArray());
+        }
+
+        [TestMethod]
+        public void TimingCache_SingleRunReflectsInPlaceSampleMutation()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d },
+                new[] { 10d, 20d });
+
+            session.GetFrametimeTimeWindow(0, 1, _options);
+            session.Runs[0].CaptureData.MsBetweenPresents[1] = 40d;
+
+            var values = session.GetFrametimeTimeWindow(0, 1, _options);
+
+            CollectionAssert.AreEqual(new[] { 10d, 40d }, values.ToArray());
+        }
+
+        [TestMethod]
+        public void TimingCache_MultipleRunsInvalidatesAfterInPlaceSampleMutation()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d },
+                new[] { 10d, 20d });
+            session.Runs.Add(new SessionRun
+            {
+                CaptureData = new SessionCaptureData(2)
+                {
+                    TimeInSeconds = new[] { 2d, 3d },
+                    MsBetweenPresents = new[] { 30d, 40d }
+                }
+            });
+
+            session.GetFrametimeTimeWindow(0, 3, _options);
+            session.Runs[1].CaptureData.MsBetweenPresents[0] = 35d;
+
+            var values = session.GetFrametimeTimeWindow(0, 3, _options);
+
+            CollectionAssert.AreEqual(new[] { 10d, 20d, 35d, 40d }, values.ToArray());
+        }
+
+        [TestMethod]
+        public void TimingCache_ValidatesMutatedSeriesWhenThatSeriesIsRequested()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d },
+                new[] { 10d, 20d });
+            session.Runs[0].CaptureData.GpuActive = new[] { 1d, 2d };
+            session.Runs.Add(new SessionRun
+            {
+                CaptureData = new SessionCaptureData(2)
+                {
+                    TimeInSeconds = new[] { 2d, 3d },
+                    MsBetweenPresents = new[] { 30d, 40d },
+                    GpuActive = new[] { 3d, 4d }
+                }
+            });
+
+            session.GetGpuActiveTimeTimeWindow(0, 3, _options);
+            session.Runs[1].CaptureData.GpuActive[0] = 5d;
+
+            // A frametime request does not need to validate the unrelated GPU series.
+            session.GetFrametimeTimeWindow(0, 3, _options);
+            var gpuValues = session.GetGpuActiveTimeTimeWindow(0, 3, _options);
+
+            CollectionAssert.AreEqual(new[] { 1d, 2d, 5d, 4d }, gpuValues.ToArray());
+        }
+
+        private static Session CreateSession(double[] times, double[] frametimes)
+        {
+            var captureData = new SessionCaptureData(times.Length)
+            {
+                TimeInSeconds = times,
+                MsBetweenPresents = frametimes,
+                MsBetweenDisplayChange = frametimes.ToArray(),
+                GpuActive = frametimes.ToArray(),
+                CpuActive = frametimes.ToArray()
+            };
+            var run = new SessionRun { CaptureData = captureData };
+            var session = new Session();
+            session.Runs.Add(run);
+            return session;
+        }
+    }
+}

--- a/source/CapFrameX.Test/ViewModel/ComparisonMetricSourceResolverTest.cs
+++ b/source/CapFrameX.Test/ViewModel/ComparisonMetricSourceResolverTest.cs
@@ -1,0 +1,95 @@
+using CapFrameX.Data.Session.Classes;
+using CapFrameX.Data.Session.Contracts;
+using CapFrameX.ViewModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace CapFrameX.Test.ViewModel
+{
+    [TestClass]
+    public class ComparisonMetricSourceResolverTest
+    {
+        [TestMethod]
+        public void ShouldUseDisplayChangeMetrics_AllSessionsHaveDisplayData_ReturnsTrue()
+        {
+            var sessions = new[]
+            {
+                CreateSession(16.6, 16.7),
+                CreateSession(8.3, 8.4)
+            };
+
+            bool result = ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(true, sessions);
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void ShouldUseDisplayChangeMetrics_OneSessionHasNoDisplayData_ReturnsFalse()
+        {
+            var sessions = new[]
+            {
+                CreateSession(16.6, 16.7),
+                CreateSession(0, double.NaN, double.PositiveInfinity)
+            };
+
+            bool result = ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(true, sessions);
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void ShouldUseDisplayChangeMetrics_OneRunHasNoDisplayData_ReturnsFalse()
+        {
+            var session = CreateSession(16.6, 16.7);
+            session.Runs.Add(CreateRun(0, 0));
+
+            bool result = ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(true,
+                new[] { session });
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void ShouldUseDisplayChangeMetrics_NotRequestedOrNoSessions_ReturnsFalse()
+        {
+            Assert.IsFalse(ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(false,
+                new[] { CreateSession(16.6) }));
+            Assert.IsFalse(ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(true,
+                new ISession[0]));
+        }
+
+        private static ISession CreateSession(params double[] displayChangeTimes)
+        {
+            return new Session
+            {
+                Runs = new List<ISessionRun>
+                {
+                    CreateRun(displayChangeTimes)
+                }
+            };
+        }
+
+        private static ISessionRun CreateRun(params double[] displayChangeTimes)
+        {
+            var captureData = new SessionCaptureData(displayChangeTimes.Length)
+            {
+                MsBetweenDisplayChange = displayChangeTimes,
+                MsBetweenPresents = CreatePresentTimes(displayChangeTimes.Length)
+            };
+
+            return new SessionRun
+            {
+                CaptureData = captureData
+            };
+        }
+
+        private static double[] CreatePresentTimes(int count)
+        {
+            var presentTimes = new double[count];
+            for (int i = 0; i < presentTimes.Length; i++)
+                presentTimes[i] = 16.6;
+
+            return presentTimes;
+        }
+    }
+}

--- a/source/CapFrameX.Test/ViewModel/FpsGraphDataContextTest.cs
+++ b/source/CapFrameX.Test/ViewModel/FpsGraphDataContextTest.cs
@@ -1,0 +1,42 @@
+using CapFrameX.Statistics.NetStandard;
+using CapFrameX.ViewModel.DataContext;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace CapFrameX.Test.ViewModel
+{
+    [TestClass]
+    public class FpsGraphDataContextTest
+    {
+        [TestMethod]
+        public void GetAlignedFinitePoints_MismatchedAndInvalidSeries_UsesTimestampIntersection()
+        {
+            var fpsPoints = new List<Point>
+            {
+                new Point(0, 60),
+                new Point(1, 61),
+                new Point(2, 62),
+                new Point(3, 63)
+            };
+            var gpuPoints = new List<Point>
+            {
+                new Point(0, 100),
+                new Point(2, double.PositiveInfinity),
+                new Point(3, 103)
+            };
+            var method = typeof(FpsGraphDataContext).GetMethod("GetAlignedFinitePoints",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            var result = (IList<Tuple<Point, Point>>)method.Invoke(null,
+                new object[] { fpsPoints, gpuPoints });
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(0d, result[0].Item1.X);
+            Assert.AreEqual(100d, result[0].Item2.Y);
+            Assert.AreEqual(3d, result[1].Item1.X);
+            Assert.AreEqual(103d, result[1].Item2.Y);
+        }
+    }
+}

--- a/source/CapFrameX.View/AggregationView.xaml
+++ b/source/CapFrameX.View/AggregationView.xaml
@@ -46,7 +46,9 @@
 				   dragdrop:DragDrop.DefaultDragAdornerOpacity="0.5"
 				   dragdrop:DragDrop.UseDefaultEffectDataTemplate="False"/>
         <DataGrid Grid.Row="1" Grid.Column="1" x:Name="AggregationItemDataGrid" Height="275" Width="700" FontSize="11"
-				  MouseLeave="AggregationItemDataGrid_MouseLeave" SelectionMode="Single" VirtualizingStackPanel.VirtualizationMode="Standard"
+				  MouseLeave="AggregationItemDataGrid_MouseLeave" SelectionMode="Single"
+				  EnableRowVirtualization="True" EnableColumnVirtualization="True"
+				  VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling"
 				  SelectedIndex="{Binding SelectedAggregationEntryIndex}" ItemsSource="{Binding AggregationEntries}"
 				  CanUserSortColumns="False" CanUserAddRows="False" AutoGenerateColumns="False" PreviewKeyDown="AggregationItemDataGrid_PreviewKeyDown"
 				  materialDesign:DataGridAssist.CellPadding="13 8 8 8" materialDesign:DataGridAssist.ColumnHeaderPadding="8" IsSynchronizedWithCurrentItem="False"

--- a/source/CapFrameX.View/ComparisonView.xaml
+++ b/source/CapFrameX.View/ComparisonView.xaml
@@ -661,7 +661,7 @@
 				</StackPanel.Style>
 			</StackPanel>
 
-            <StackPanel Grid.Column="6" Margin="10 10 5 0" Orientation="Horizontal">
+			<StackPanel Grid.Column="6" Margin="10 10 5 0" Orientation="Horizontal">
                 <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Foreground="{DynamicResource MaterialDesignBody}">Further Settings</TextBlock>
                 <materialDesign:PopupBox Foreground="{DynamicResource MaterialDesignBody}" StaysOpen="True" ToolTipService.ShowDuration="25000" PlacementMode="TopAndAlignCentres">
                     <materialDesign:Card Width="Auto" Margin="0 0 0 -10">
@@ -676,8 +676,7 @@
                                 <TextBlock VerticalAlignment="Center" Foreground="{DynamicResource MaterialDesignBody}">GPU-Busy times:</TextBlock>
                                 <ToggleButton Name="GPUActiveMetricsToggleButton" Margin="10 0 0 0" Style="{StaticResource MaterialDesignSwitchToggleButton}"
 								  ToolTip="Show GPU-Busy times instead of regular frametimes" IsChecked="{Binding ShowGpuActiveLineCharts}"/>
-                            </StackPanel>
-
+			</StackPanel>
                             <StackPanel Margin="10 10 10 0" VerticalAlignment="Center" Orientation="Horizontal"
 							Visibility="{Binding IsBarChartTabActive, Converter={StaticResource TrueToVisibleConverter}}">
                                 <TextBlock VerticalAlignment="Center" Foreground="{DynamicResource MaterialDesignBody}">Relative Mode:</TextBlock>
@@ -742,6 +741,9 @@
                     </Style>
                 </StackPanel.Style>
             </StackPanel>
+			<TextBlock Grid.Column="8" Margin="10 10 10 0" HorizontalAlignment="Right" VerticalAlignment="Center"
+				Text="{Binding ComparisonMetricSourceDescription}" TextTrimming="CharacterEllipsis"
+				ToolTip="All compared records use this timing source; mixed display/present comparisons are prevented." />
         </Grid>
 		<!-- Copmparison List -->
 		<StackPanel Margin="5 10 5 0" Grid.Column="1" Grid.RowSpan="2" Orientation="Vertical">

--- a/source/CapFrameX.View/ControlView.xaml
+++ b/source/CapFrameX.View/ControlView.xaml
@@ -196,6 +196,10 @@
 					        dragdrop:DragDrop.DefaultDragAdornerOpacity="0.5"
 					        dragdrop:DragDrop.UseDefaultEffectDataTemplate="False"
                             Style="{StaticResource MaterialDesignDataGrid}"
+                            EnableRowVirtualization="True"
+                            EnableColumnVirtualization="True"
+                            VirtualizingPanel.IsVirtualizing="True"
+                            VirtualizingPanel.VirtualizationMode="Recycling"
                             Background="{DynamicResource MaterialDesignBackground}">
                         <DataGrid.Resources>
                             <Style TargetType="{x:Type DataGridRow}">

--- a/source/CapFrameX.ViewModel/AggregationViewModel.cs
+++ b/source/CapFrameX.ViewModel/AggregationViewModel.cs
@@ -40,6 +40,17 @@ namespace CapFrameX.ViewModel
         private bool _showResultString;
         private string _aggregationResultString = string.Empty;
         private bool _supressCollectionChanged;
+        private readonly Dictionary<string, AggregationWorkingSet> _workingSets =
+            new Dictionary<string, AggregationWorkingSet>(StringComparer.OrdinalIgnoreCase);
+
+        private sealed class AggregationWorkingSet
+        {
+            public ISession Session;
+            public List<double> FrametimeValues;
+            public List<double> DisplayTimeValues;
+            public long FileLength;
+            public long LastWriteTimeUtcTicks;
+        }
 
         public int SelectedAggregationEntryIndex
         {
@@ -217,6 +228,10 @@ namespace CapFrameX.ViewModel
         public void RemoveAggregationEntry(IAggregationEntry entry)
         {
             _fileRecordInfoList.Remove(entry.FileRecordInfo);
+            if (entry.FileRecordInfo != null)
+            {
+                _workingSets.Remove(entry.FileRecordInfo.FullPath);
+            }
             AggregationEntries.Remove(entry);
         }
 
@@ -274,17 +289,14 @@ namespace CapFrameX.ViewModel
                     return;
             }
 
-            _fileRecordInfoList.Add(recordInfo);
-
-            session = session ?? _recordManager.LoadData(recordInfo.FullPath);
-            var frametimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToList();
-            var displaytimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToList();
+            var workingSet = GetWorkingSet(recordInfo, session);
 
             var metricAnalysis = _statisticProvider
-                .GetMetricAnalysis(frametimes, displaytimes, _appConfiguration.UseDisplayChangeMetrics,
+                .GetMetricAnalysis(workingSet.FrametimeValues, workingSet.DisplayTimeValues,
+                    _appConfiguration.UseDisplayChangeMetrics,
                     SelectedSecondMetric.ConvertToString(), SelectedThirdMetric.ConvertToString());
 
-            AggregationEntries.Add(new AggregationEntry()
+            var entry = new AggregationEntry()
             {
                 GameName = recordInfo.GameName,
                 CreationDate = recordInfo.CreationDate,
@@ -294,7 +306,18 @@ namespace CapFrameX.ViewModel
                 ThirdMetricValue = metricAnalysis.Third,
                 MetricAnalysis = metricAnalysis,
                 FileRecordInfo = recordInfo
-            });
+            };
+
+            _fileRecordInfoList.Add(recordInfo);
+            try
+            {
+                AggregationEntries.Add(entry);
+            }
+            catch
+            {
+                _fileRecordInfoList.Remove(recordInfo);
+                throw;
+            }
         }
 
         private void UpdateAggregationEntries()
@@ -302,20 +325,17 @@ namespace CapFrameX.ViewModel
             if (!_fileRecordInfoList.Any())
                 return;
 
-            AggregationEntries.Clear();
-
-            _supressCollectionChanged = true;
+            var updatedEntries = new List<AggregationEntry>(_fileRecordInfoList.Count);
             foreach (var recordInfo in _fileRecordInfoList)
             {
-                var localSession = _recordManager.LoadData(recordInfo.FullPath);
-                var frametimes = localSession.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToList();
-                var displaytimes = localSession.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToList();
+                var workingSet = GetWorkingSet(recordInfo);
 
                 var metricAnalysis = _statisticProvider
-                    .GetMetricAnalysis(frametimes, displaytimes, _appConfiguration.UseDisplayChangeMetrics,
+                    .GetMetricAnalysis(workingSet.FrametimeValues, workingSet.DisplayTimeValues,
+                        _appConfiguration.UseDisplayChangeMetrics,
                         SelectedSecondMetric.ConvertToString(), SelectedThirdMetric.ConvertToString());
 
-                AggregationEntries.Add(new AggregationEntry()
+                updatedEntries.Add(new AggregationEntry()
                 {
                     GameName = recordInfo.GameName,
                     CreationDate = recordInfo.CreationDate,
@@ -323,17 +343,38 @@ namespace CapFrameX.ViewModel
                     AverageValue = metricAnalysis.Average,
                     SecondMetricValue = metricAnalysis.Second,
                     ThirdMetricValue = metricAnalysis.Third,
-                    MetricAnalysis = metricAnalysis
+                    MetricAnalysis = metricAnalysis,
+                    FileRecordInfo = recordInfo
                 });
             }
-            _supressCollectionChanged = false;
-            OnAggregationEntriesChanged();
+
+            var previousEntries = AggregationEntries.ToList();
+            _supressCollectionChanged = true;
+            try
+            {
+                AggregationEntries.Clear();
+                foreach (var entry in updatedEntries)
+                    AggregationEntries.Add(entry);
+            }
+            catch
+            {
+                AggregationEntries.Clear();
+                foreach (var entry in previousEntries)
+                    AggregationEntries.Add(entry);
+                throw;
+            }
+            finally
+            {
+                _supressCollectionChanged = false;
+                OnAggregationEntriesChanged();
+            }
         }
 
         private void OnClearTable()
         {
             AggregationEntries.Clear();
             _fileRecordInfoList.Clear();
+            _workingSets.Clear();
             AggregationResultString = string.Empty;
             ShowResultString = false;
         }
@@ -342,17 +383,14 @@ namespace CapFrameX.ViewModel
         {
             try
             {
-                var concatedFrametimesInclude = new List<double>();
-                var concatedDisplaytimesInclude = new List<double>();
+                var workingSets = _fileRecordInfoList.Select(info => GetWorkingSet(info)).ToList();
+                var concatedFrametimesInclude = new List<double>(workingSets.Sum(set => set.FrametimeValues.Count));
+                var concatedDisplaytimesInclude = new List<double>(workingSets.Sum(set => set.DisplayTimeValues.Count));
 
-                foreach (var recordInfo in _fileRecordInfoList)
+                foreach (var workingSet in workingSets)
                 {
-                    var localSession = _recordManager.LoadData(recordInfo.FullPath);
-                    var frametimes = localSession.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToList();
-                    var displaytimes = localSession.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToList();
-
-                    concatedFrametimesInclude.AddRange(frametimes);
-                    concatedDisplaytimesInclude.AddRange(displaytimes);
+                    concatedFrametimesInclude.AddRange(workingSet.FrametimeValues);
+                    concatedDisplaytimesInclude.AddRange(workingSet.DisplayTimeValues);
                 }
 
                 var resultString = _statisticProvider
@@ -382,17 +420,17 @@ namespace CapFrameX.ViewModel
                         .GetOutlierAnalysis(AggregationEntries.Select(analysis => analysis.MetricAnalysis).ToList(),
                         _appConfiguration.RelatedMetricAggregation, _appConfiguration.OutlierPercentageAggregation);
 
-                var concatedFrametimesExclude = new List<double>();
-                var concatedDisplaytimesExclude = new List<double>();
+                var includedWorkingSets = _fileRecordInfoList
+                    .Where((x, i) => !outlierFlags[i])
+                    .Select(info => GetWorkingSet(info))
+                    .ToList();
+                var concatedFrametimesExclude = new List<double>(includedWorkingSets.Sum(set => set.FrametimeValues.Count));
+                var concatedDisplaytimesExclude = new List<double>(includedWorkingSets.Sum(set => set.DisplayTimeValues.Count));
 
-                foreach (var recordInfo in _fileRecordInfoList.Where((x, i) => !outlierFlags[i]))
+                foreach (var workingSet in includedWorkingSets)
                 {
-                    var localSession = _recordManager.LoadData(recordInfo.FullPath);
-                    var frametimes = localSession.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToList();
-                    var displaytimes = localSession.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToList();
-
-                    concatedFrametimesExclude.AddRange(frametimes);
-                    concatedDisplaytimesExclude.AddRange(displaytimes);
+                    concatedFrametimesExclude.AddRange(workingSet.FrametimeValues);
+                    concatedDisplaytimesExclude.AddRange(workingSet.DisplayTimeValues);
                 }
 
                 var resultString = _statisticProvider
@@ -416,26 +454,62 @@ namespace CapFrameX.ViewModel
 
         private void WriteAggregatedFileAsync(bool[] outlierFlags)
         {
+            var includedSessions = _fileRecordInfoList
+                .Where((x, i) => !outlierFlags[i])
+                .Select(info => GetWorkingSet(info).Session)
+                .ToList();
+
             // write aggregated file
             Task.Run(() =>
             {
                 string process = string.Empty;
-                var filteredFileRecordInfoList = _fileRecordInfoList.Where((x, i) => !outlierFlags[i]);
 
                 var hwInfo = new List<ISessionInfo>();
 
                 var runs = new List<ISessionRun>();
 
-                foreach (var recordInfo in filteredFileRecordInfoList)
+                foreach (var session in includedSessions)
                 {
-                    var otherSession = _recordManager.LoadData(recordInfo.FullPath);
-                    process = otherSession.Info.ProcessName;
-                    hwInfo.Add(otherSession.Info);
-                    runs.AddRange(otherSession.Runs);
+                    process = session.Info.ProcessName;
+                    hwInfo.Add(session.Info);
+                    runs.AddRange(session.Runs);
                 }
 
                 _recordManager.SaveSessionRunsToFile(runs, process, string.Empty, null, hwInfo);
             });
+        }
+
+        private AggregationWorkingSet GetWorkingSet(IFileRecordInfo recordInfo, ISession suppliedSession = null)
+        {
+            var fileInfo = recordInfo.FileInfo;
+            fileInfo?.Refresh();
+            long fileLength = fileInfo?.Exists == true ? fileInfo.Length : 0;
+            long lastWriteTimeUtcTicks = fileInfo?.Exists == true ? fileInfo.LastWriteTimeUtc.Ticks : 0;
+
+            if (suppliedSession == null
+                && _workingSets.TryGetValue(recordInfo.FullPath, out var cached)
+                && cached.FileLength == fileLength
+                && cached.LastWriteTimeUtcTicks == lastWriteTimeUtcTicks)
+            {
+                return cached;
+            }
+
+            var session = suppliedSession ?? _recordManager.LoadData(recordInfo.FullPath);
+            if (session == null)
+            {
+                throw new InvalidOperationException($"Unable to load aggregation record '{recordInfo.FullPath}'.");
+            }
+
+            var workingSet = new AggregationWorkingSet
+            {
+                Session = session,
+                FrametimeValues = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToList(),
+                DisplayTimeValues = session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToList(),
+                FileLength = fileLength,
+                LastWriteTimeUtcTicks = lastWriteTimeUtcTicks
+            };
+            _workingSets[recordInfo.FullPath] = workingSet;
+            return workingSet;
         }
 
         public void OnNavigatedTo(NavigationContext navigationContext)

--- a/source/CapFrameX.ViewModel/CapFrameX.ViewModel.csproj
+++ b/source/CapFrameX.ViewModel/CapFrameX.ViewModel.csproj
@@ -195,6 +195,7 @@
     <Compile Include="CaptureViewModel.cs" />
     <Compile Include="ColorRessource.cs" />
     <Compile Include="ComparisonColorManager.cs" />
+    <Compile Include="ComparisonMetricSourceResolver.cs" />
     <Compile Include="ComparisonRecordInfoWrapper.cs" />
     <Compile Include="ComparisonViewModel.cs" />
     <Compile Include="ComparisonViewModelLabel.cs" />

--- a/source/CapFrameX.ViewModel/ComparisonMetricSourceResolver.cs
+++ b/source/CapFrameX.ViewModel/ComparisonMetricSourceResolver.cs
@@ -1,0 +1,61 @@
+using CapFrameX.Data.Session.Contracts;
+using System;
+using System.Collections.Generic;
+
+namespace CapFrameX.ViewModel
+{
+    public static class ComparisonMetricSourceResolver
+    {
+        public static bool ShouldUseDisplayChangeMetrics(bool requested, IEnumerable<ISession> sessions)
+        {
+            if (!requested || sessions == null)
+                return false;
+
+            bool hasSession = false;
+            foreach (ISession session in sessions)
+            {
+                hasSession = true;
+                if (!HasValidDisplayChangeSample(session))
+                    return false;
+            }
+
+            return hasSession;
+        }
+
+        private static bool HasValidDisplayChangeSample(ISession session)
+        {
+            if (session?.Runs == null)
+                return false;
+
+            bool hasCaptureData = false;
+            foreach (ISessionRun run in session.Runs)
+            {
+                double[] presentTimes = run?.CaptureData?.MsBetweenPresents;
+                if (!HasValidTimingSample(presentTimes))
+                    continue;
+
+                hasCaptureData = true;
+                double[] displayChangeTimes = run?.CaptureData?.MsBetweenDisplayChange;
+                if (!HasValidTimingSample(displayChangeTimes))
+                    return false;
+            }
+
+            return hasCaptureData;
+        }
+
+        private static bool HasValidTimingSample(double[] values)
+        {
+            if (values == null)
+                return false;
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                double value = values[i];
+                if (value > 0 && !double.IsNaN(value) && !double.IsInfinity(value))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/source/CapFrameX.ViewModel/ComparisonViewModel.cs
+++ b/source/CapFrameX.ViewModel/ComparisonViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using CapFrameX.Contracts.Configuration;
 using CapFrameX.Contracts.Data;
 using CapFrameX.Data;
+using CapFrameX.Data.Session.Contracts;
 using CapFrameX.EventAggregation.Messages;
 using CapFrameX.Extensions;
 using CapFrameX.Extensions.NetStandard;
@@ -30,6 +31,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reactive;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Windows;
 using System.Windows.Controls;
@@ -112,6 +114,9 @@ namespace CapFrameX.ViewModel
         private bool _isDistributionChartDirty = true;
         private bool _isFpsChartDirty = true;
         private bool _isFrametimeChartDirty = true;
+        private bool _useDisplayChangeSamplesForComparison;
+        private string _comparisonMetricSourceDescription = "Source: Presents";
+        private readonly ISubject<Unit> _rangeSliderUpdate = new Subject<Unit>();
 
         public Array FirstMetricItems => Enum.GetValues(typeof(EMetric))
             .Cast<EMetric>().Where(metric => metric != EMetric.None && metric != EMetric.GpuActiveAverage && metric != EMetric.GpuActiveOnePercentLowAverage && metric != EMetric.GpuActiveP1)
@@ -346,6 +351,19 @@ namespace CapFrameX.ViewModel
             }
         }
 
+        public string ComparisonMetricSourceDescription
+        {
+            get => _comparisonMetricSourceDescription;
+            private set
+            {
+                if (_comparisonMetricSourceDescription == value)
+                    return;
+
+                _comparisonMetricSourceDescription = value;
+                RaisePropertyChanged();
+            }
+        }
+
         public double BarChartHeight
         {
             get { return _barChartHeight; }
@@ -415,7 +433,7 @@ namespace CapFrameX.ViewModel
                 SetChartUpdateFlags();
 
                 if (ComparisonRangeSliderRealTime)
-                    UpdateCharts();
+                    _rangeSliderUpdate.OnNext(default);
             }
         }
 
@@ -432,7 +450,7 @@ namespace CapFrameX.ViewModel
                 SetChartUpdateFlags();
 
                 if (ComparisonRangeSliderRealTime)
-                    UpdateCharts();
+                    _rangeSliderUpdate.OnNext(default);
             }
         }
 
@@ -461,7 +479,7 @@ namespace CapFrameX.ViewModel
                 RaisePropertyChanged(nameof(IsVarianceChartTabActive));
                 RaisePropertyChanged(nameof(IsDistributionTabActive));
                 OnChartItemChanged();
-                UpdateCharts();
+                UpdateChartsSafely();
 
                 if (!IsLineChartTabActive && !IsDistributionTabActive)
                 {
@@ -633,7 +651,7 @@ namespace CapFrameX.ViewModel
                 else
                     ComparisonLShapeYAxisLabel = "FPS" + Environment.NewLine + " ";
                 RaisePropertyChanged();
-                UpdateCharts();
+                UpdateChartsSafely();
             }
         }
 
@@ -698,7 +716,7 @@ namespace CapFrameX.ViewModel
                 _isDistributionChartDirty = true;
                 RaisePropertyChanged();
                 InitializePlotModels();
-                UpdateCharts();
+                UpdateChartsSafely();
             }
         }
 
@@ -711,7 +729,7 @@ namespace CapFrameX.ViewModel
                 IsFpsChartDirty = true;
                 IsFrametimeChartDirty = true;
                 RaisePropertyChanged();
-                UpdateCharts();
+                UpdateChartsSafely();
             }
         }
 
@@ -869,6 +887,22 @@ namespace CapFrameX.ViewModel
             SubscribeToSelectRecord();
             SubscribeToUpdateRecordInfos();
             SubscribeToThemeChanged();
+            _rangeSliderUpdate
+                .Throttle(TimeSpan.FromMilliseconds(75))
+                .ObserveOnDispatcher()
+                .Subscribe(_ => UpdateChartsSafely(), error =>
+                    _logger?.LogError(error, "The comparison chart update pipeline stopped unexpectedly."));
+
+            var configurationChanges = _appConfiguration.OnValueChanged;
+            if (configurationChanges != null)
+            {
+                configurationChanges
+                    .Where(change => change.key == nameof(IAppConfiguration.UseDisplayChangeMetrics))
+                    .ObserveOnDispatcher()
+                    .Subscribe(_ => UpdateChartsSafely(), error =>
+                        _logger?.LogError(error,
+                            "The comparison display-metric update subscription stopped unexpectedly."));
+            }
 
             LineGraphColors = new ObservableCollection<ComparisonColorItems>(
                 _appConfiguration.ComparisonLineGraphColors
@@ -1058,6 +1092,8 @@ namespace CapFrameX.ViewModel
                 };
                 ComparisonDistributionModel.Annotations.Add(Line); ;
             }
+
+            UpdateComparisonMetricSourceLabels();
 
         }
 
@@ -1258,6 +1294,14 @@ namespace CapFrameX.ViewModel
         {
             if (!_doUpdateCharts)
                 return;
+
+            bool metricSourceChanged = UpdateComparisonMetricSource();
+            if (metricSourceChanged)
+            {
+                foreach (ComparisonRecordInfoWrapper record in ComparisonRecords)
+                    SetMetrics(record);
+            }
+
             ResetBarChartSeriesTitles();
 
             //Clear series and reset axes of all charts
@@ -1311,6 +1355,127 @@ namespace CapFrameX.ViewModel
             RaisePropertyChanged(nameof(MetricAndLabelOptionsEnabled));
         }
 
+        private void UpdateChartsSafely()
+        {
+            try
+            {
+                UpdateCharts();
+            }
+            catch (Exception exception)
+            {
+                SetChartUpdateFlags();
+                _logger?.LogError(exception,
+                    "A comparison chart update failed. The next update will retry the complete redraw.");
+            }
+        }
+
+        private bool UpdateComparisonMetricSource(ComparisonRecordInfoWrapper additionalRecord = null)
+        {
+            IEnumerable<ISession> sessions = ComparisonRecords
+                .Select(record => record.WrappedRecordInfo.Session);
+            if (additionalRecord != null)
+            {
+                sessions = sessions.Concat(new[] { additionalRecord.WrappedRecordInfo.Session });
+            }
+
+            bool useDisplayChangeSamples = ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(
+                _appConfiguration.UseDisplayChangeMetrics, sessions);
+            bool sourceChanged = useDisplayChangeSamples != _useDisplayChangeSamplesForComparison;
+            _useDisplayChangeSamplesForComparison = useDisplayChangeSamples;
+
+            bool hasRecords = ComparisonRecords.Any() || additionalRecord != null;
+            if (_useDisplayChangeSamplesForComparison)
+            {
+                ComparisonMetricSourceDescription = "Source: Display changes (Average FPS: Presents)";
+            }
+            else if (_appConfiguration.UseDisplayChangeMetrics && hasRecords)
+            {
+                ComparisonMetricSourceDescription = "Source: Presents (display data unavailable)";
+            }
+            else
+            {
+                ComparisonMetricSourceDescription = "Source: Presents";
+            }
+
+            UpdateComparisonMetricSourceLabels();
+            return sourceChanged;
+        }
+
+        private void UpdateComparisonMetricSourceLabels()
+        {
+            string timingSource = _useDisplayChangeSamplesForComparison ? "Display time" : "Present frametime";
+            string fpsSource = _useDisplayChangeSamplesForComparison ? "Display FPS" : "Present FPS";
+
+            var frametimeAxis = ComparisonFrametimesModel?.GetAxisOrDefault("yAxis", null);
+            if (frametimeAxis != null)
+                frametimeAxis.Title = ShowGpuActiveLineCharts ? "GPU active time [ms]" : $"{timingSource} [ms]";
+
+            var fpsAxis = ComparisonFpsModel?.GetAxisOrDefault("yAxis", null);
+            if (fpsAxis != null)
+                fpsAxis.Title = $"{fpsSource} [1/s]";
+
+            var distributionXAxis = ComparisonDistributionModel?.GetAxisOrDefault("xAxis", null);
+            if (distributionXAxis != null)
+                distributionXAxis.Title = $"{timingSource} [ms]";
+
+            var distributionYAxis = ComparisonDistributionModel?.GetAxisOrDefault("yAxis", null);
+            if (distributionYAxis != null)
+            {
+                distributionYAxis.Title = _useDisplayChangeSamplesForComparison
+                    ? "Display Time Distribution [%]"
+                    : "Present Frametime Distribution [%]";
+            }
+
+            if (ShowGpuActiveLineCharts)
+            {
+                ComparisonLShapeYAxisLabel = SelectedChartView == "FPS"
+                    ? "GPU active FPS" + Environment.NewLine + " "
+                    : "GPU active time (ms)" + Environment.NewLine + " ";
+            }
+            else
+            {
+                ComparisonLShapeYAxisLabel = SelectedChartView == "FPS"
+                    ? fpsSource + Environment.NewLine + " "
+                    : timingSource + " (ms)" + Environment.NewLine + " ";
+            }
+
+            if (ComparisonRowChartSeriesCollection != null)
+            {
+                for (int i = 0; i < ComparisonRowChartSeriesCollection.Count; i++)
+                {
+                    var rowSeries = ComparisonRowChartSeriesCollection[i] as RowSeries;
+                    if (rowSeries != null)
+                        rowSeries.Title = GetDescriptionAndFpsUnit(GetMetricByIndex(i));
+                }
+            }
+
+            if (ComparisonRowChartSeriesCollectionLegend != null)
+            {
+                for (int i = 0; i < ComparisonRowChartSeriesCollectionLegend.Count; i++)
+                {
+                    var rowSeries = ComparisonRowChartSeriesCollectionLegend[i] as RowSeries;
+                    if (rowSeries != null)
+                        rowSeries.Title = GetDescriptionAndFpsUnit(GetMetricByIndex(i));
+                }
+            }
+        }
+
+        private static bool TryGetLastFrameStart(ISession session, out double lastFrameStart)
+        {
+            lastFrameStart = double.NaN;
+            if (session?.Runs == null)
+                return false;
+
+            foreach (var run in session.Runs)
+            {
+                double[] timeInSeconds = run?.CaptureData?.TimeInSeconds;
+                if (timeInSeconds != null && timeInSeconds.Length > 0)
+                    lastFrameStart = timeInSeconds[timeInSeconds.Length - 1];
+            }
+
+            return !double.IsNaN(lastFrameStart) && !double.IsInfinity(lastFrameStart);
+        }
+
         private void OnChartItemChanged()
         {
             if (SelectedChartItem?.Header.ToString().Contains("Line") ?? false)
@@ -1329,6 +1494,7 @@ namespace CapFrameX.ViewModel
 
         private void OnMetricChanged()
         {
+            UpdateComparisonMetricSource();
             SetRowSeries();
 
             double GetMetricValue(IList<double> sequence, EMetric metric) =>
@@ -1343,8 +1509,10 @@ namespace CapFrameX.ViewModel
                 var frametimeTimeWindow = currentWrappedComparisonInfo.WrappedRecordInfo.Session
                     .GetFrametimeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
 
-                var displayChangeTimeWindow = currentWrappedComparisonInfo.WrappedRecordInfo.Session
-                    .GetDisplayChangeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
+                var displayChangeTimeWindow = _useDisplayChangeSamplesForComparison
+                    ? currentWrappedComparisonInfo.WrappedRecordInfo.Session
+                        .GetDisplayChangeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None)
+                    : null;
 
                 var gpuBusyTimeWindow = currentWrappedComparisonInfo.WrappedRecordInfo.Session
                     .GetGpuActiveTimeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
@@ -1383,7 +1551,7 @@ namespace CapFrameX.ViewModel
                         }
                         else
                         {
-                            var samples = _appConfiguration.UseDisplayChangeMetrics
+                            var samples = _useDisplayChangeSamplesForComparison
                                 ? displayChangeTimeWindow : frametimeTimeWindow;
 
                             metricValue = GetMetricValue(samples, metric);
@@ -1447,7 +1615,7 @@ namespace CapFrameX.ViewModel
         private void OnRangeSliderChanged()
         {
             UpdateRangeSliderParameter();
-            UpdateCharts();
+            UpdateChartsSafely();
         }
 
         public void OnRangeSliderValuesChanged()
@@ -1459,13 +1627,13 @@ namespace CapFrameX.ViewModel
                 LastSeconds = MaxRecordingTime;
 
             if (!ComparisonRangeSliderRealTime)
-                UpdateCharts();
+                UpdateChartsSafely();
         }
 
         public void OnRangeSliderDragCompleted()
         {
             if (!ComparisonRangeSliderRealTime)
-                UpdateCharts();
+                UpdateChartsSafely();
         }
 
         internal class ChartLabel
@@ -1562,8 +1730,9 @@ namespace CapFrameX.ViewModel
 
             foreach (var record in ComparisonRecords)
             {
-                if (record.WrappedRecordInfo.Session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).Last() > longestRecord)
-                    longestRecord = record.WrappedRecordInfo.Session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).Last();
+                double lastFrameStart;
+                if (TryGetLastFrameStart(record.WrappedRecordInfo.Session, out lastFrameStart))
+                    longestRecord = Math.Max(longestRecord, lastFrameStart);
             }
 
             MaxRecordingTime = longestRecord;
@@ -1579,74 +1748,15 @@ namespace CapFrameX.ViewModel
 
         private void UpdateAxesMinMaxFrametimeChart()
         {
-            if (ComparisonRecords == null || !ComparisonRecords.Any())
-                return;
-
             var xAxis = ComparisonFrametimesModel.GetAxisOrDefault("xAxis", null);
             var yAxis = ComparisonFrametimesModel.GetAxisOrDefault("yAxis", null);
 
-            if (xAxis == null || yAxis == null)
+            double xMin, xMax, yMin, yMax;
+            if (xAxis == null || yAxis == null
+                || !TryGetSeriesBounds(ComparisonFrametimesModel, out xMin, out xMax, out yMin, out yMax))
                 return;
 
             xAxis.Reset();
-
-            double xMin = 0;
-            double xMax = 0;
-            double yMin = 0;
-            double yMax = 0;
-
-            double startTime = FirstSeconds;
-            double endTime = LastSeconds;
-
-            var sessionParallelQuery = ComparisonRecords.Select(record => record.WrappedRecordInfo.Session).AsParallel();
-
-            xMin = sessionParallelQuery.Min(session =>
-            {
-                var window = session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                if (window.Any())
-                    return window.First().X;
-                else
-                    return double.MaxValue;
-            });
-
-            xMax = sessionParallelQuery.Max(session =>
-            {
-                var window = session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                if (window.Any())
-                    return window.Last().X;
-                else
-                    return double.MinValue;
-            });
-
-            yMin = sessionParallelQuery.Min(session =>
-            {
-                IList<Point> window = null;
-
-                if (ShowGpuActiveLineCharts)
-                    window = session.GetGpuActiveTimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                else
-                    window = session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.Min(pnt => pnt.Y);
-                else
-                    return double.MaxValue;
-            });
-
-            yMax = sessionParallelQuery.Max(session =>
-            {
-                IList<Point> window = null;
-
-                if (ShowGpuActiveLineCharts)
-                    window = session.GetGpuActiveTimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                else
-                    window = session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.Max(pnt => pnt.Y);
-                else
-                    return double.MinValue;
-            });
 
             xAxis.Minimum = xMin;
             xAxis.Maximum = xMax;
@@ -1657,79 +1767,17 @@ namespace CapFrameX.ViewModel
             ComparisonFrametimesModel.InvalidatePlot(true);
         }
 
-        // ToDo: Optimieren!
         private void UpdateAxesMinMaxFpsChart()
         {
-            if (ComparisonRecords == null || !ComparisonRecords.Any())
-                return;
-
             var xAxis = ComparisonFpsModel.GetAxisOrDefault("xAxis", null);
             var yAxis = ComparisonFpsModel.GetAxisOrDefault("yAxis", null);
 
-            if (xAxis == null || yAxis == null)
+            double xMin, xMax, yMin, yMax;
+            if (xAxis == null || yAxis == null
+                || !TryGetSeriesBounds(ComparisonFpsModel, out xMin, out xMax, out yMin, out yMax))
                 return;
 
             xAxis.Reset();
-
-            double xMin = 0;
-            double xMax = 0;
-            double yMin = 0;
-            double yMax = 0;
-
-            double startTime = FirstSeconds;
-            double endTime = LastSeconds;
-
-            var sessionParallelQuery = ComparisonRecords.Select(record => record.WrappedRecordInfo.Session).AsParallel();
-
-            xMin = sessionParallelQuery.Min(session =>
-            {
-                IList<Point> window = session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.First().X;
-                else
-                    return double.MaxValue;
-            });
-
-            xMax = sessionParallelQuery.Max(session =>
-            {
-                IList<Point> window = session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.Last().X;
-                else
-                    return double.MinValue;
-            });
-
-            yMin = sessionParallelQuery.Min(session =>
-            {
-                IList<Point> window = null;
-
-                //if (ShowGpuActiveLineCharts)
-                //	window = session.GetGpuActiveFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode);
-                //else
-                window = session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode);
-
-                if (window.Any())
-                    return window.Min(pnt => pnt.Y);
-                else
-                    return double.MaxValue;
-            });
-
-            yMax = sessionParallelQuery.Max(session =>
-            {
-                IList<Point> window = null;
-
-                //if (ShowGpuActiveLineCharts)
-                //	window = session.GetGpuActiveFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode);
-                //else
-                window = session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode);
-
-                if (window.Any())
-                    return window.Max(pnt => pnt.Y);
-                else
-                    return double.MinValue;
-            });
 
             xAxis.Minimum = xMin;
             xAxis.Maximum = xMax;
@@ -1742,74 +1790,20 @@ namespace CapFrameX.ViewModel
 
         private void UpdateAxesMinMaxDistributionChart()
         {
-
-            if (ComparisonRecords == null || !ComparisonRecords.Any())
-                return;
-
             var xAxis = ComparisonDistributionModel.GetAxisOrDefault("xAxis", null);
             var yAxis = ComparisonDistributionModel.GetAxisOrDefault("yAxis", null);
 
-            if (xAxis == null || yAxis == null)
+            double xMin, xMax, yMin, yMax;
+            if (xAxis == null || yAxis == null
+                || !TryGetSeriesBounds(ComparisonDistributionModel, out xMin, out xMax, out yMin, out yMax))
                 return;
 
-            double startTime = FirstSeconds;
-            double endTime = LastSeconds;
-
             xAxis.Reset();
-
-            double xMin = 0;
-            double xMax = 0;
-            double yMin = 0;
-            double yMax = 0;
-
-            var sessionParallelQuery = ComparisonRecords.Select(record => record.WrappedRecordInfo.Session).AsParallel();
-
-            xMin = sessionParallelQuery.Min(session =>
-            {
-                var window = session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                if (window.Any())
-                    return window.First().X;
-                else
-                    return double.MaxValue;
-            });
-
-            xMax = sessionParallelQuery.Max(session =>
-            {
-                var window = session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                if (window.Any())
-                    return window.Last().X;
-                else
-                    return double.MinValue;
-            });
-
-            yMin = sessionParallelQuery.Min(session =>
-            {
-                IList<Point> window = null;
-
-                window = session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.Min(pnt => pnt.Y);
-                else
-                    return double.MaxValue;
-            });
-
-            yMax = sessionParallelQuery.Max(session =>
-            {
-                IList<Point> window = null;
-
-                window = session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.Max(pnt => pnt.Y);
-                else
-                    return double.MinValue;
-            });
 
             xAxis.Minimum = xMin - 1;
             xAxis.Maximum = xMax;
 
-            yAxis.Minimum = yMin - (yMax - yMin) / 6;
+            yAxis.Minimum = 0;
             yAxis.Maximum = yMax + (yMax - yMin) / 6;
 
             double stepSize = 0;
@@ -1828,6 +1822,36 @@ namespace CapFrameX.ViewModel
 
 
             ComparisonDistributionModel.InvalidatePlot(true);
+        }
+
+        private static bool TryGetSeriesBounds(PlotModel plotModel, out double xMin, out double xMax,
+            out double yMin, out double yMax)
+        {
+            xMin = double.MaxValue;
+            xMax = double.MinValue;
+            yMin = double.MaxValue;
+            yMax = double.MinValue;
+            bool hasPoints = false;
+
+            foreach (var series in plotModel.Series.OfType<OxyPlot.Series.LineSeries>())
+            {
+                foreach (var point in series.Points)
+                {
+                    if (double.IsNaN(point.X) || double.IsInfinity(point.X)
+                        || double.IsNaN(point.Y) || double.IsInfinity(point.Y))
+                    {
+                        continue;
+                    }
+
+                    hasPoints = true;
+                    xMin = Math.Min(xMin, point.X);
+                    xMax = Math.Max(xMax, point.X);
+                    yMin = Math.Min(yMin, point.Y);
+                    yMax = Math.Max(yMax, point.Y);
+                }
+            }
+
+            return hasPoints;
         }
 
         private void UpdateBarChartHeight()
@@ -2009,17 +2033,25 @@ namespace CapFrameX.ViewModel
             double endTime = LastSeconds;
             var session = wrappedComparisonInfo.WrappedRecordInfo.Session;
 
-            IEnumerable<Point> frametimePoints = null;
+            IList<Point> frametimePoints = null;
 
             if (ShowGpuActiveLineCharts)
             {
                 frametimePoints = session.GetGpuActiveTimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None)
-                   .Select(pnt => new Point(pnt.X, pnt.Y));
+                    .ToList();
             }
             else
             {
-                frametimePoints = session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None)
-                   .Select(pnt => new Point(pnt.X, pnt.Y));
+                if (_useDisplayChangeSamplesForComparison)
+                {
+                    frametimePoints = session.GetDisplayChangeTimePointsTimeWindow(startTime, endTime,
+                        _appConfiguration, ERemoveOutlierMethod.None);
+                }
+                else
+                {
+                    frametimePoints = session.GetFrametimePointsTimeWindow(startTime, endTime,
+                        _appConfiguration, ERemoveOutlierMethod.None);
+                }
             }
 
             var chartTitle = string.Empty;
@@ -2037,7 +2069,8 @@ namespace CapFrameX.ViewModel
 
             };
 
-            frametimeSeries.Points.AddRange(frametimePoints.Select(pnt => new DataPoint(pnt.X, pnt.Y)));
+            frametimeSeries.Points.AddRange(frametimePoints
+                .Select(pnt => new DataPoint(pnt.X, pnt.Y)));
             ComparisonFrametimesModel.Series.Add(frametimeSeries);
         }
 
@@ -2047,14 +2080,22 @@ namespace CapFrameX.ViewModel
             double endTime = LastSeconds;
             var session = wrappedComparisonInfo.WrappedRecordInfo.Session;
 
-            IEnumerable<Point> fpsPoints = null;
+            IList<Point> fpsPoints = null;
 
             //if (ShowGpuActiveLineCharts)
             //	fpsPoints = session.GetGpuActiveFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode)
             //	   .Select(pnt => new Point(pnt.X, pnt.Y));
             //else
-            fpsPoints = session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode)
-                .Select(pnt => new Point(pnt.X, pnt.Y));
+            if (_useDisplayChangeSamplesForComparison)
+            {
+                fpsPoints = session.GetDisplayFpsPointsTimeWindow(startTime, endTime,
+                    _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode);
+            }
+            else
+            {
+                fpsPoints = session.GetFpsPointsTimeWindow(startTime, endTime,
+                    _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode);
+            }
 
             var chartTitle = string.Empty;
 
@@ -2073,7 +2114,8 @@ namespace CapFrameX.ViewModel
 
             };
 
-            fpsSeries.Points.AddRange(fpsPoints.Select(pnt => new DataPoint(pnt.X, pnt.Y)));
+            fpsSeries.Points.AddRange(fpsPoints
+                .Select(pnt => new DataPoint(pnt.X, pnt.Y)));
             ComparisonFpsModel.Series.Add(fpsSeries);
         }
 
@@ -2083,11 +2125,17 @@ namespace CapFrameX.ViewModel
             double endTime = LastSeconds;
             var session = wrappedComparisonInfo.WrappedRecordInfo.Session;
 
-            IEnumerable<Point> distributionPoints = null;
-
-
-            distributionPoints = session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None)
-                .Select(pnt => new Point(pnt.X, pnt.Y));
+            IList<Point> distributionPoints = null;
+            if (_useDisplayChangeSamplesForComparison)
+            {
+                distributionPoints = session.GetDisplayTimeDistributionPoints(startTime, endTime,
+                    _appConfiguration, ERemoveOutlierMethod.None);
+            }
+            else
+            {
+                distributionPoints = session.GetFrametimeDistributionPoints(startTime, endTime,
+                    _appConfiguration, ERemoveOutlierMethod.None);
+            }
 
             var chartTitle = string.Empty;
 
@@ -2105,7 +2153,8 @@ namespace CapFrameX.ViewModel
 
             };
 
-            distributionSeries.Points.AddRange(distributionPoints.Select(pnt => new DataPoint(pnt.X, pnt.Y)));
+            distributionSeries.Points.AddRange(distributionPoints
+                .Select(pnt => new DataPoint(pnt.X, pnt.Y)));
             ComparisonDistributionModel.Series.Add(distributionSeries);
         }
 
@@ -2123,7 +2172,18 @@ namespace CapFrameX.ViewModel
             }
             else
             {
-                frametimeTimeWindow = wrappedComparisonInfo.WrappedRecordInfo.Session.GetFrametimeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
+                if (_useDisplayChangeSamplesForComparison)
+                {
+                    frametimeTimeWindow = wrappedComparisonInfo.WrappedRecordInfo.Session
+                        .GetDisplayChangeTimeWindow(startTime, endTime, _appConfiguration,
+                            ERemoveOutlierMethod.None);
+                }
+                else
+                {
+                    frametimeTimeWindow = wrappedComparisonInfo.WrappedRecordInfo.Session
+                        .GetFrametimeTimeWindow(startTime, endTime, _appConfiguration,
+                            ERemoveOutlierMethod.None);
+                }
             }
 
             var fpsTimeWindow = frametimeTimeWindow?.Select(ft => 1000 / ft).ToList();
@@ -2181,16 +2241,20 @@ namespace CapFrameX.ViewModel
 
         private void AddToVarianceCharts(ComparisonRecordInfoWrapper wrappedComparisonInfo)
         {
-            IList<double> variances;
+            var session = wrappedComparisonInfo.WrappedRecordInfo.Session;
+            double lastFrameStart;
+            IList<double> samples = new List<double>();
+            if (TryGetLastFrameStart(session, out lastFrameStart))
+            {
+                var endTime = LastSeconds <= 0 || LastSeconds > lastFrameStart ? lastFrameStart : LastSeconds;
 
-            if (_appConfiguration.UseDisplayChangeMetrics)
-            {
-                variances = _frametimeStatisticProvider.GetDisplayTimeVariancePercentages(wrappedComparisonInfo.WrappedRecordInfo.Session);
+                samples = _useDisplayChangeSamplesForComparison
+                    ? session.GetDisplayChangeTimeWindow(FirstSeconds, endTime,
+                        _appConfiguration, ERemoveOutlierMethod.None)
+                    : session.GetFrametimeTimeWindow(FirstSeconds, endTime,
+                        _appConfiguration, ERemoveOutlierMethod.None);
             }
-            else
-            {
-                variances = _frametimeStatisticProvider.GetFrametimeVariancePercentages(wrappedComparisonInfo.WrappedRecordInfo.Session);
-            }                
+            var variances = _frametimeStatisticProvider.GetVariancePercentages(samples);
 
             VarianceStatisticCollection[0].Values.Insert(0, variances[0]);
             VarianceStatisticCollection[1].Values.Insert(0, variances[1]);
@@ -2228,7 +2292,23 @@ namespace CapFrameX.ViewModel
             else
                 description = $"{metric.GetDescription()} FPS";
 
-            return description;
+            string source;
+            if (metric == EMetric.GpuActiveAverage || metric == EMetric.GpuActiveP1
+                || metric == EMetric.GpuActiveOnePercentLowAverage)
+            {
+                source = "GPU active";
+            }
+            else if (metric == EMetric.Average || metric == EMetric.CpuFpsPerWatt
+                || metric == EMetric.GpuFpsPerWatt)
+            {
+                source = "Present";
+            }
+            else
+            {
+                source = _useDisplayChangeSamplesForComparison ? "Display" : "Present";
+            }
+
+            return $"{description} ({source})";
         }
 
         private EMetric GetMetricByIndex(int index)
@@ -2249,10 +2329,17 @@ namespace CapFrameX.ViewModel
         {
             string infoText = string.Empty;
             var session = _recordManager.LoadData(fileRecordInfo.FullPath);
-            var frameTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToList();
-            var recordTime = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).Last();
             if (session != null)
             {
+                var frameTimes = session.Runs
+                    .Where(run => run?.CaptureData?.MsBetweenPresents != null)
+                    .SelectMany(run => run.CaptureData.MsBetweenPresents)
+                    .ToList();
+                double recordTime;
+                TryGetLastFrameStart(session, out recordTime);
+                if (double.IsNaN(recordTime))
+                    recordTime = 0;
+
                 var newLine = Environment.NewLine;
                 infoText += $"{fileRecordInfo.CreationDate} {fileRecordInfo.CreationTime}" + newLine +
                     $"{frameTimes.Count()} frames in {Math.Round(recordTime, 2, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture)}s";
@@ -2326,7 +2413,7 @@ namespace CapFrameX.ViewModel
                 .Subscribe(msg =>
                 {
                     InitializePlotModels();
-                    UpdateCharts();
+                    UpdateChartsSafely();
                 });
         }
 

--- a/source/CapFrameX.ViewModel/ComparisonViewModelItems.cs
+++ b/source/CapFrameX.ViewModel/ComparisonViewModelItems.cs
@@ -26,6 +26,12 @@ namespace CapFrameX.ViewModel
             var wrappedComparisonRecordInfo = GetWrappedRecordInfo(comparisonRecordInfo);
 
             // Insert into list (sorted)
+            bool metricSourceChanged = UpdateComparisonMetricSource(wrappedComparisonRecordInfo);
+            if (metricSourceChanged)
+            {
+                foreach (ComparisonRecordInfoWrapper existingRecord in ComparisonRecords)
+                    SetMetrics(existingRecord);
+            }
             SetMetrics(wrappedComparisonRecordInfo);
             InsertComparisonRecordsSorted(wrappedComparisonRecordInfo);
 
@@ -55,11 +61,23 @@ namespace CapFrameX.ViewModel
         private void SetMetrics(ComparisonRecordInfoWrapper wrappedComparisonRecordInfo)
         {
             double startTime = FirstSeconds;
-            double lastFrameStart = wrappedComparisonRecordInfo.WrappedRecordInfo.Session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).Last();
-            double endTime = LastSeconds > lastFrameStart ? lastFrameStart : lastFrameStart + LastSeconds;
+            double lastFrameStart;
+            if (!TryGetLastFrameStart(wrappedComparisonRecordInfo.WrappedRecordInfo.Session, out lastFrameStart))
+            {
+                wrappedComparisonRecordInfo.WrappedRecordInfo.FirstMetric = double.NaN;
+                wrappedComparisonRecordInfo.WrappedRecordInfo.SecondMetric = double.NaN;
+                wrappedComparisonRecordInfo.WrappedRecordInfo.ThirdMetric = double.NaN;
+                wrappedComparisonRecordInfo.WrappedRecordInfo.SortingVariances = 0;
+                return;
+            }
+
+            double endTime = LastSeconds <= 0 || LastSeconds > lastFrameStart ? lastFrameStart : LastSeconds;
 
             var frametimeTimeWindow = wrappedComparisonRecordInfo.WrappedRecordInfo.Session.GetFrametimeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-            var displayChangeTimeWindow = wrappedComparisonRecordInfo.WrappedRecordInfo.Session.GetDisplayChangeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
+            var displayChangeTimeWindow = _useDisplayChangeSamplesForComparison
+                ? wrappedComparisonRecordInfo.WrappedRecordInfo.Session.GetDisplayChangeTimeWindow(startTime,
+                    endTime, _appConfiguration, ERemoveOutlierMethod.None)
+                : null;
             var gpuActiveTimeWindow = wrappedComparisonRecordInfo.WrappedRecordInfo.Session.GetGpuActiveTimeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
 
             double GeMetricValue(IList<double> sequence, EMetric metric) =>
@@ -94,7 +112,7 @@ namespace CapFrameX.ViewModel
                 }
                 else
                 {
-                    var samples = _appConfiguration.UseDisplayChangeMetrics
+                    var samples = _useDisplayChangeSamplesForComparison
                         ? displayChangeTimeWindow : frametimeTimeWindow;
 
                     wrappedComparisonRecordInfo.WrappedRecordInfo.FirstMetric =
@@ -131,7 +149,7 @@ namespace CapFrameX.ViewModel
                 }
                 else
                 {
-                    var samples = _appConfiguration.UseDisplayChangeMetrics
+                    var samples = _useDisplayChangeSamplesForComparison
                         ? displayChangeTimeWindow : frametimeTimeWindow;
 
                     wrappedComparisonRecordInfo.WrappedRecordInfo.SecondMetric =
@@ -168,7 +186,7 @@ namespace CapFrameX.ViewModel
                 }
                 else
                 {
-                    var samples = _appConfiguration.UseDisplayChangeMetrics
+                    var samples = _useDisplayChangeSamplesForComparison
                         ? displayChangeTimeWindow : frametimeTimeWindow;
 
                     wrappedComparisonRecordInfo.WrappedRecordInfo.ThirdMetric =
@@ -176,16 +194,10 @@ namespace CapFrameX.ViewModel
                 }
             }
 
-            IList<double> variances;
-
-            if (_appConfiguration.UseDisplayChangeMetrics)
-            {
-                variances = _frametimeStatisticProvider.GetDisplayTimeVariancePercentages(wrappedComparisonRecordInfo.WrappedRecordInfo.Session);
-            }
-            else
-            {
-                variances = _frametimeStatisticProvider.GetFrametimeVariancePercentages(wrappedComparisonRecordInfo.WrappedRecordInfo.Session);
-            }
+            var varianceSamples = _useDisplayChangeSamplesForComparison
+                ? displayChangeTimeWindow
+                : frametimeTimeWindow;
+            var variances = _frametimeStatisticProvider.GetVariancePercentages(varianceSamples);
 
             wrappedComparisonRecordInfo.WrappedRecordInfo.SortingVariances
                 = variances[0] + variances[1];

--- a/source/CapFrameX.ViewModel/ControlViewModel.cs
+++ b/source/CapFrameX.ViewModel/ControlViewModel.cs
@@ -24,6 +24,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Input;
 
 namespace CapFrameX.ViewModel
@@ -59,6 +60,10 @@ namespace CapFrameX.ViewModel
         private bool _customRamDescriptionChanged = false;
         private bool _customGameNameChanged = false;
         private bool _customCommentChanged = false;
+        private readonly SemaphoreSlim _selectionLoadSemaphore = new SemaphoreSlim(1, 1);
+        private Task<ISession> _selectedSessionTask = Task.FromResult<ISession>(null);
+        private CancellationTokenSource _selectionLoadCancellation = new CancellationTokenSource();
+        private int _selectionVersion;
 
         public bool ShowCreationDate
         {
@@ -124,6 +129,10 @@ namespace CapFrameX.ViewModel
             get { return _selectedRecordInfo; }
             set
             {
+                if (ReferenceEquals(_selectedRecordInfo, value))
+                {
+                    return;
+                }
 
                 _selectedRecordInfo = value;
                 OnSelectedRecordInfoChanged();
@@ -769,39 +778,111 @@ namespace CapFrameX.ViewModel
             }
         }
 
-        public void OnRecordSelectByDoubleClick()
+        public async void OnRecordSelectByDoubleClick()
         {
-            if (SelectedRecordInfo != null && _selectSessionEvent != null)
+            var selectedRecordInfo = SelectedRecordInfo;
+            if (selectedRecordInfo != null && _selectSessionEvent != null)
             {
-                var session = _recordManager.LoadData(SelectedRecordInfo.FullPath);
-                _selectSessionEvent.Publish(new ViewMessages.SelectSession(session, SelectedRecordInfo));
+                try
+                {
+                    // Reuse the selection load. Besides avoiding duplicate parsing, awaiting this
+                    // task preserves UpdateSession-before-SelectSession event ordering.
+                    var session = await _selectedSessionTask;
+                    if (session != null && ReferenceEquals(_selectedRecordInfo, selectedRecordInfo))
+                    {
+                        _selectSessionEvent.Publish(new ViewMessages.SelectSession(session, selectedRecordInfo));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error selecting record {RecordPath}.", selectedRecordInfo.FullPath);
+                }
             }
         }
 
         private void OnSelectedRecordInfoChanged()
         {
-            if (_selectedRecordInfo is null)
+            var selectionVersion = Interlocked.Increment(ref _selectionVersion);
+            var newCancellation = new CancellationTokenSource();
+            var previousCancellation = Interlocked.Exchange(ref _selectionLoadCancellation, newCancellation);
+            previousCancellation?.Cancel();
+            previousCancellation?.Dispose();
+            var selectedRecordInfo = _selectedRecordInfo;
+
+            if (selectedRecordInfo is null)
             {
+                _selectedSessionTask = Task.FromResult<ISession>(null);
                 ResetInfoEditBoxes();
+                ResetDescriptionChangedFlags();
             }
             else
             {
-                var session = _recordManager.LoadData(_selectedRecordInfo.FullPath);
-                if (session is ISession)
+                // These values come from FileRecordInfo and do not depend on parsing the capture.
+                // Updating them now prevents the previous record's metadata remaining visible
+                // while a large session is loaded in the background.
+                CustomCpuDescription = string.Copy(selectedRecordInfo.ProcessorName ?? string.Empty);
+                CustomGpuDescription = string.Copy(selectedRecordInfo.GraphicCardName ?? string.Empty);
+                CustomRamDescription = string.Copy(selectedRecordInfo.SystemRamInfo ?? string.Empty);
+                CustomGameName = string.Copy(selectedRecordInfo.GameName ?? string.Empty);
+                CustomComment = string.Copy(selectedRecordInfo.Comment ?? string.Empty);
+                ResetDescriptionChangedFlags();
+                _selectedSessionTask = LoadSelectedSessionAsync(selectedRecordInfo, selectionVersion,
+                    newCancellation.Token);
+            }
+        }
+
+        private async Task<ISession> LoadSelectedSessionAsync(IFileRecordInfo selectedRecordInfo, int selectionVersion,
+            CancellationToken cancellationToken)
+        {
+            var lockTaken = false;
+            try
+            {
+                await _selectionLoadSemaphore.WaitAsync(cancellationToken);
+                lockTaken = true;
+
+                // Rapid keyboard or mouse navigation can queue several selections while an HDD
+                // read is active. Only the newest queued selection should touch the disk.
+                if (cancellationToken.IsCancellationRequested
+                    || !IsCurrentSelection(selectedRecordInfo, selectionVersion))
+                {
+                    return null;
+                }
+
+                var session = await Task.Run(() => _recordManager.LoadData(selectedRecordInfo.FullPath), cancellationToken);
+                if (session != null && !cancellationToken.IsCancellationRequested
+                    && IsCurrentSelection(selectedRecordInfo, selectionVersion))
                 {
                     if (_updateSessionEvent != null)
                     {
-                        _updateSessionEvent.Publish(new ViewMessages.UpdateSession(session, SelectedRecordInfo));
+                        _updateSessionEvent.Publish(new ViewMessages.UpdateSession(session, selectedRecordInfo));
                     }
-                    CustomCpuDescription = string.Copy(SelectedRecordInfo.ProcessorName ?? string.Empty);
-                    CustomGpuDescription = string.Copy(SelectedRecordInfo.GraphicCardName ?? string.Empty);
-                    CustomRamDescription = string.Copy(SelectedRecordInfo.SystemRamInfo ?? string.Empty);
-                    CustomGameName = string.Copy(SelectedRecordInfo.GameName ?? string.Empty);
-                    CustomComment = string.Copy(SelectedRecordInfo.Comment ?? string.Empty);
+                    return session;
+                }
+
+                return null;
+            }
+            catch (OperationCanceledException)
+            {
+                return null;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error loading selected record {RecordPath}.", selectedRecordInfo.FullPath);
+                return null;
+            }
+            finally
+            {
+                if (lockTaken)
+                {
+                    _selectionLoadSemaphore.Release();
                 }
             }
+        }
 
-            ResetDescriptionChangedFlags();
+        private bool IsCurrentSelection(IFileRecordInfo selectedRecordInfo, int selectionVersion)
+        {
+            return Volatile.Read(ref _selectionVersion) == selectionVersion
+                && ReferenceEquals(_selectedRecordInfo, selectedRecordInfo);
         }
 
         private void OnPressDeleteKey()

--- a/source/CapFrameX.ViewModel/DataContext/FpsGraphDataContext.cs
+++ b/source/CapFrameX.ViewModel/DataContext/FpsGraphDataContext.cs
@@ -3,6 +3,7 @@ using OxyPlot;
 using OxyPlot.Axes;
 using Prism.Commands;
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Windows.Input;
 using System.Globalization;
@@ -13,6 +14,7 @@ using CapFrameX.Statistics.PlotBuilder;
 using CapFrameX.Statistics.PlotBuilder.Contracts;
 using Prism.Events;
 using CapFrameX.Extensions.NetStandard;
+using CapFrameX.Statistics.NetStandard;
 using CapFrameX.Statistics.NetStandard.Contracts;
 
 namespace CapFrameX.ViewModel.DataContext
@@ -133,14 +135,15 @@ namespace CapFrameX.ViewModel.DataContext
             if (RecordSession == null)
                 return;
 
-            var fps = RecordDataServer.GetFpsTimeWindow();
-            var gpuActiveFps = RecordDataServer.GetGpuActiveFpsTimeWindow();
+            var alignedPoints = GetAlignedFinitePoints(
+                RecordDataServer.GetFpsPointTimeWindow(),
+                RecordDataServer.GetGpuActiveFpsPointTimeWindow());
             StringBuilder builder = new StringBuilder();
 
-            for (int i = 0; i < fps.Count; i++)
+            foreach (var points in alignedPoints)
             {
-                builder.Append(Math.Round(fps[i], 2, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture) + "\t" +
-                    Math.Round(gpuActiveFps[i], 2, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
+                builder.Append(Math.Round(points.Item1.Y, 2, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture) + "\t" +
+                    Math.Round(points.Item2.Y, 2, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
             }
 
             Clipboard.SetDataObject(builder.ToString(), false);
@@ -168,18 +171,55 @@ namespace CapFrameX.ViewModel.DataContext
             if (RecordSession == null)
                 return;
 
-            var fpsPoints = RecordDataServer.GetFpsPointTimeWindow();
-            var gpuActiveFpsPoints = RecordDataServer.GetGpuActiveFpsPointTimeWindow();
+            var alignedPoints = GetAlignedFinitePoints(
+                RecordDataServer.GetFpsPointTimeWindow(),
+                RecordDataServer.GetGpuActiveFpsPointTimeWindow());
             StringBuilder builder = new StringBuilder();
 
-            for (int i = 0; i < fpsPoints.Count; i++)
+            foreach (var points in alignedPoints)
             {
-                builder.Append(Math.Round(fpsPoints[i].X, 2).ToString(CultureInfo.InvariantCulture) + "\t" +
-                    Math.Round(fpsPoints[i].Y, 2).ToString(CultureInfo.InvariantCulture) + "\t"+
-                    Math.Round(gpuActiveFpsPoints[i].Y, 2).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
+                builder.Append(Math.Round(points.Item1.X, 2).ToString(CultureInfo.InvariantCulture) + "\t" +
+                    Math.Round(points.Item1.Y, 2).ToString(CultureInfo.InvariantCulture) + "\t"+
+                    Math.Round(points.Item2.Y, 2).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
             }
 
             Clipboard.SetDataObject(builder.ToString(), false);
         }
+
+        private static IList<Tuple<Point, Point>> GetAlignedFinitePoints(
+            IList<Point> fpsPoints, IList<Point> gpuActiveFpsPoints)
+        {
+            var alignedPoints = new List<Tuple<Point, Point>>();
+            if (fpsPoints == null || gpuActiveFpsPoints == null)
+                return alignedPoints;
+
+            int fpsIndex = 0;
+            int gpuIndex = 0;
+            while (fpsIndex < fpsPoints.Count && gpuIndex < gpuActiveFpsPoints.Count)
+            {
+                var fpsPoint = fpsPoints[fpsIndex];
+                var gpuPoint = gpuActiveFpsPoints[gpuIndex];
+                if (fpsPoint.X < gpuPoint.X)
+                {
+                    fpsIndex++;
+                    continue;
+                }
+                if (gpuPoint.X < fpsPoint.X)
+                {
+                    gpuIndex++;
+                    continue;
+                }
+
+                if (IsFinite(fpsPoint.Y) && IsFinite(gpuPoint.Y))
+                    alignedPoints.Add(Tuple.Create(fpsPoint, gpuPoint));
+                fpsIndex++;
+                gpuIndex++;
+            }
+
+            return alignedPoints;
+        }
+
+        private static bool IsFinite(double value)
+            => !double.IsNaN(value) && !double.IsInfinity(value);
     }
 }

--- a/source/CapFrameX.ViewModel/DataThresholdViewModel.cs
+++ b/source/CapFrameX.ViewModel/DataThresholdViewModel.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -138,7 +139,8 @@ namespace CapFrameX.ViewModel
 
             if (sampleSubset != null)
             {
-                Task.Factory.StartNew(() => SetFpsThresholdChart(sampleSubset));
+                var cancellationToken = BeginThresholdUpdate(out int updateVersion);
+                Task.Run(() => SetFpsThresholdChart(sampleSubset, updateVersion, cancellationToken, true), cancellationToken);
                 SetThresholdLabels();
             }
         }
@@ -157,20 +159,32 @@ namespace CapFrameX.ViewModel
                 }).ToArray();
         }
 
-        private void SetFpsThresholdChart(IList<double> samples)
+        private void SetFpsThresholdChart(IList<double> samples, int updateVersion,
+            CancellationToken cancellationToken, bool thresholdOnlyUpdate = false)
         {
+            if (!IsCurrentThresholdChartUpdate(updateVersion, cancellationToken, thresholdOnlyUpdate)) return;
             if (samples == null || !samples.Any()) return;
 
             var thresholdCounts = _frametimeStatisticProvider.GetFpsThresholdCounts(samples, ThresholdToggleButtonIsChecked);
+            cancellationToken.ThrowIfCancellationRequested();
             var thresholdCountValues = new ChartValues<double>();
             thresholdCountValues.AddRange(thresholdCounts.Select(val => (double)val / samples.Count));
 
             var thresholdTimes = _frametimeStatisticProvider.GetFpsThresholdTimes(samples, ThresholdToggleButtonIsChecked);
+            cancellationToken.ThrowIfCancellationRequested();
+            double totalSampleTime = 0;
+            for (int i = 0; i < samples.Count; i++)
+            {
+                if ((i & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
+                totalSampleTime += samples[i];
+            }
             var thresholdTimesValues = new ChartValues<double>();
-            thresholdTimesValues.AddRange(thresholdTimes.Select(val => val / samples.Sum()));
+            thresholdTimesValues.AddRange(thresholdTimes.Select(val => val / totalSampleTime));
 
             Application.Current.Dispatcher.Invoke(new Action(() =>
             {
+                if (!IsCurrentThresholdChartUpdate(updateVersion, cancellationToken, thresholdOnlyUpdate)) return;
+
                 if (!ShowThresholdTimes)
                 {
                     YAxisLabel = "Frames";
@@ -197,7 +211,7 @@ namespace CapFrameX.ViewModel
                             Values = thresholdTimesValues,
                             Fill = new SolidColorBrush(Color.FromRgb(34, 151, 243)),
                             DataLabels = true,
-                            LabelPoint = p => ThresholdShowAbsoluteValues ? ((samples.Sum()* p.Y) * 1E-03).ToString("N1", CultureInfo.InvariantCulture) + "s" :
+                            LabelPoint = p => ThresholdShowAbsoluteValues ? ((totalSampleTime * p.Y) * 1E-03).ToString("N1", CultureInfo.InvariantCulture) + "s" :
                                 (100 * p.Y).ToString("N1", CultureInfo.InvariantCulture) + "%",
                             MaxColumnWidth = 40
                         }
@@ -207,6 +221,8 @@ namespace CapFrameX.ViewModel
 
             Application.Current.Dispatcher.Invoke(new Action(() =>
             {
+                if (!IsCurrentThresholdChartUpdate(updateVersion, cancellationToken, thresholdOnlyUpdate)) return;
+
                 if (!ShowThresholdTimes)
                 {
                     YAxisLabel = "Frames";
@@ -233,13 +249,22 @@ namespace CapFrameX.ViewModel
                             Values = thresholdTimesValues,
                             Fill = new SolidColorBrush(Color.FromRgb(34, 151, 243)),
                             DataLabels = true,
-                            LabelPoint = p => ThresholdShowAbsoluteValues ? ((samples.Sum()* p.Y) * 1E-03).ToString("N1", CultureInfo.InvariantCulture) + "s" :
+                            LabelPoint = p => ThresholdShowAbsoluteValues ? ((totalSampleTime * p.Y) * 1E-03).ToString("N1", CultureInfo.InvariantCulture) + "s" :
                                 (100 * p.Y).ToString("N1", CultureInfo.InvariantCulture) + "%",
                             MaxColumnWidth = 40
                         }
                     };
                 }
             }));
+        }
+
+        private bool IsCurrentThresholdChartUpdate(int updateVersion,
+            CancellationToken cancellationToken, bool thresholdOnlyUpdate)
+        {
+            return !cancellationToken.IsCancellationRequested
+                && (thresholdOnlyUpdate
+                    ? IsCurrentThresholdUpdate(updateVersion)
+                    : IsCurrentAnalysisUpdate(updateVersion));
         }
     }
 }

--- a/source/CapFrameX.ViewModel/DataViewModel.cs
+++ b/source/CapFrameX.ViewModel/DataViewModel.cs
@@ -4,6 +4,7 @@ using CapFrameX.Data;
 using CapFrameX.Data.Session.Contracts;
 using CapFrameX.EventAggregation.Messages;
 using CapFrameX.Extensions;
+using CapFrameX.Extensions.NetStandard;
 using CapFrameX.MVVM.Dialogs;
 using CapFrameX.Sensor.Reporting;
 using CapFrameX.Sensor.Reporting.Contracts;
@@ -28,6 +29,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -98,6 +100,14 @@ namespace CapFrameX.ViewModel
         private bool _isDistributionChartDirty = true;
         private bool _isFpsChartDirty = true;
         private bool _isFrametimeChartDirty = true;
+        private int _analysisUpdateVersion;
+        private int _thresholdUpdateVersion;
+        private int _secondaryChartUpdateVersion;
+        private int _sensorReportUpdateVersion;
+        private CancellationTokenSource _analysisUpdateCancellation = new CancellationTokenSource();
+        private CancellationTokenSource _thresholdUpdateCancellation = new CancellationTokenSource();
+        private CancellationTokenSource _secondaryChartUpdateCancellation = new CancellationTokenSource();
+        private CancellationTokenSource _sensorReportUpdateCancellation = new CancellationTokenSource();
 
         private ISubject<Unit> _onUpdateChart = new BehaviorSubject<Unit>(default);
 
@@ -336,6 +346,7 @@ namespace CapFrameX.ViewModel
             {
                 _appConfiguration.StutteringFactor = value;
                 RaisePropertyChanged();
+                SetChartUpdateFlags(true, true, false);
                 _onUpdateChart.OnNext(default);
             }
         }
@@ -347,6 +358,7 @@ namespace CapFrameX.ViewModel
             {
                 _appConfiguration.StutteringThreshold = value;
                 RaisePropertyChanged();
+                SetChartUpdateFlags(true, true, false);
                 _onUpdateChart.OnNext(default);
             }
         }
@@ -870,51 +882,84 @@ namespace CapFrameX.ViewModel
 
         private void Setup()
         {
-            _onUpdateChart.Subscribe(_ =>
+            _onUpdateChart
+                .Throttle(TimeSpan.FromMilliseconds(75))
+                .ObserveOnDispatcher()
+                .Subscribe(_ => UpdateDirtyChartsSafely(), error =>
+                    _logger?.LogError(error, "The analysis chart update pipeline stopped unexpectedly."));
+
+            var configurationChanges = _appConfiguration.OnValueChanged;
+            if (configurationChanges != null)
             {
-                
-                if (SelectedChartHeader.Contains("Distribution") && _isDistributionChartDirty)
-                {
-                    FrametimeDistributionGraphDataContext.BuildPlotmodel(GetVisibleGraphs());
-                    _isDistributionChartDirty = false;
-                }
-                    
-
-                if (SelectedChartHeader.Contains("FPS") && _isFpsChartDirty)
-                {
-                    FpsGraphDataContext.BuildPlotmodel(GetVisibleGraphs());
-                    _isFpsChartDirty = false;
-                }
-                   
-
-                if (SelectedChartHeader.Contains("Times") && _isFrametimeChartDirty)
-                {
-                    FrametimeGraphDataContext.BuildPlotmodel(GetVisibleGraphs(), plotModel =>
+                configurationChanges
+                    .Where(change => change.key == nameof(IAppConfiguration.UseDisplayChangeMetrics))
+                    .ObserveOnDispatcher()
+                    .Subscribe(_ =>
                     {
-                        FrametimeGraphDataContext.UpdateAxis(EPlotAxis.YAXISFRAMETIMES, axis =>
-                        {
-                            var tuple = GetYAxisSettingFromSelection(SelecetedChartYAxisSetting);
-                            SetFrametimeChartYAxisSetting(tuple);
-                        });
-                    });
-                    _isFrametimeChartDirty = false;
-                }
-                RaisePropertyChanged(nameof(GpuActiveDeviationPercentage));
-            });
+                        SetChartUpdateFlags();
+                        DemandUpdateCharts();
+                        UpdateSecondaryCharts();
+                        _onUpdateChart.OnNext(default);
+                    }, error => _logger?.LogError(error,
+                        "The display-metric analysis update subscription stopped unexpectedly."));
+            }
+        }
+
+        private void UpdateDirtyChartsSafely()
+        {
+            try
+            {
+                UpdateDirtyCharts();
+            }
+            catch (Exception exception)
+            {
+                SetChartUpdateFlags();
+                _logger?.LogError(exception,
+                    "An analysis chart update failed. The next update will retry the complete redraw.");
+            }
+        }
+
+        private void UpdateDirtyCharts()
+        {
+            if (SelectedChartHeader.Contains("Distribution") && _isDistributionChartDirty)
+            {
+                FrametimeDistributionGraphDataContext.BuildPlotmodel(GetVisibleGraphs());
+                _isDistributionChartDirty = false;
+            }
+
+            if (SelectedChartHeader.Contains("FPS") && _isFpsChartDirty)
+            {
+                FpsGraphDataContext.BuildPlotmodel(GetVisibleGraphs());
+                _isFpsChartDirty = false;
+            }
+
+            if (SelectedChartHeader.Contains("Times") && _isFrametimeChartDirty)
+            {
+                FrametimeGraphDataContext.BuildPlotmodel(GetVisibleGraphs(), plotModel =>
+                {
+                    var axis = plotModel.Axes.FirstOrDefault(candidate =>
+                        candidate.Key == EPlotAxis.YAXISFRAMETIMES.GetDescription());
+                    if (axis != null)
+                    {
+                        var tuple = GetYAxisSettingFromSelection(SelecetedChartYAxisSetting);
+                        axis.Reset();
+                        axis.Minimum = tuple.Item1;
+                        axis.Maximum = tuple.Item2;
+                    }
+                });
+                _isFrametimeChartDirty = false;
+            }
+
+            RaisePropertyChanged(nameof(GpuActiveDeviationPercentage));
         }
 
         partial void InitializeStatisticParameter();
 
         private void OnAcceptParameterSettings()
         {
-            Task.Factory.StartNew(() =>
-            {
-                var frametimeSubset = GetFrametimesSubset();
-                var sampleSubset = _appConfiguration.UseDisplayChangeMetrics
-                    ? GetDisplayChangeTimesSubset() : frametimeSubset;
-
-                SetStaticChart(frametimeSubset, sampleSubset, GetGpuActiveTimesSubset());
-            });
+            // A metric-only refresh must not cancel a full range update and leave its
+            // other charts stale. Re-issue the coherent chart family instead.
+            DemandUpdateCharts();
         }
 
         private void OnSliderRangeChanged()
@@ -950,9 +995,11 @@ namespace CapFrameX.ViewModel
 
             var gpuActiveTimes = GetGpuActiveTimesSubset();
             var frametimes = GetFrametimesSubset();
-            var sampleSubset = _appConfiguration.UseDisplayChangeMetrics
-                ? GetDisplayChangeTimesSubset() : frametimes;
-            var animationErrorsAbs = GetAnimationErrorsSubset()?.Select(error => Math.Abs(error)).ToList();
+            var sampleSubset = GetMetricSamplesSubset(frametimes);
+            var animationErrorsAbs = GetAnimationErrorsSubset()?
+                .Where(IsFinite)
+                .Select(error => Math.Abs(error))
+                .ToList();
 
             double GetFrametimeMetricValue(IList<double> sequence, EMetric metric) =>
               Math.Round(_frametimeStatisticProvider.GetFrametimeMetricValue(sequence, metric), 2);
@@ -1333,7 +1380,9 @@ namespace CapFrameX.ViewModel
                 // Update PC latency
                 IsPcLatencyAvailable = _session.Runs.All(run => !run.CaptureData.PcLatency.IsNullOrEmpty()) && _session.Runs.All(run =>
                 {
-                    var filteredValues = run.CaptureData.PcLatency.Where(x => !double.IsNaN(x) && x > 0);
+                    var filteredValues = run.CaptureData.PcLatency
+                        .Where(x => !double.IsNaN(x) && !double.IsInfinity(x) && x > 0)
+                        .ToList();
 
                     if (!filteredValues.Any())
                     {
@@ -1365,14 +1414,19 @@ namespace CapFrameX.ViewModel
 
                 if (IsPcLatencyAvailable)
                 {
-                    var averagePcLatency = _session.Runs.Average(run => run.CaptureData.PcLatency.Where(x => !double.IsNaN(x)).Average());
+                    var latencyValues = _session.Runs
+                        .SelectMany(run => run.CaptureData.PcLatency)
+                        .Where(x => !double.IsNaN(x) && !double.IsInfinity(x) && x > 0)
+                        .ToList();
+                    var averagePcLatency = latencyValues.Average();
                     AvgPcLatency = $"PC Latency: {Math.Round(averagePcLatency, 1, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture)}ms";
                 }
 
                 // Update Animation Error
                 IsAnimationErrorAvailable = _session.Runs.All(run => !run.CaptureData.AnimationError.IsNullOrEmpty()) && _session.Runs.All(run =>
                 {
-                    var filteredValues = run.CaptureData.AnimationError.Where(x => !double.IsNaN(x));
+                    var filteredValues = run.CaptureData.AnimationError
+                        .Where(x => !double.IsNaN(x) && !double.IsInfinity(x));
                     return filteredValues.Any();
                 });
 
@@ -1445,68 +1499,114 @@ namespace CapFrameX.ViewModel
 
         private void UpdateSensorSessionReport()
         {
-            SensorReportItems.Clear();
-            SensorReport.GetReportFromSessionSensorData(_session.Runs.Select(run => run.SensorData2).Cast<ISessionSensorData>(),
-               _localRecordDataServer.CurrentTime, _localRecordDataServer.CurrentTime + _localRecordDataServer.WindowLength)
-               .ForEach(SensorReportItems.Add);
+            var cancellationToken = BeginUpdate(ref _sensorReportUpdateVersion,
+                ref _sensorReportUpdateCancellation, out int updateVersion);
+            var session = _session;
+            if (session == null)
+                return;
+
+            double startTime = _localRecordDataServer.CurrentTime;
+            double endTime = startTime + _localRecordDataServer.WindowLength;
+            Task.Run(() =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var report = SensorReport.GetReportFromSessionSensorData(
+                    session.Runs.Select(run => run.SensorData2).Cast<ISessionSensorData>(), startTime, endTime)
+                    .ToList();
+                cancellationToken.ThrowIfCancellationRequested();
+                return report;
+            }, cancellationToken)
+                .ContinueWith(task =>
+                {
+                    if (task.IsFaulted)
+                    {
+                        _logger?.LogError(task.Exception?.GetBaseException(),
+                            "Unable to calculate the sensor report for the selected range.");
+                        return;
+                    }
+                    if (task.Status != TaskStatus.RanToCompletion
+                        || cancellationToken.IsCancellationRequested
+                        || Volatile.Read(ref _sensorReportUpdateVersion) != updateVersion)
+                    {
+                        return;
+                    }
+
+                    Application.Current.Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        if (cancellationToken.IsCancellationRequested
+                            || Volatile.Read(ref _sensorReportUpdateVersion) != updateVersion)
+                            return;
+
+                        SensorReportItems.Clear();
+                        task.Result.ForEach(SensorReportItems.Add);
+                    }));
+                }, TaskScheduler.Default);
         }
 
         private void UpdateMainCharts()
         {
+            var cancellationToken = BeginAnalysisUpdate(out int updateVersion);
             if (!_doUpdateCharts)
                 return;
 
             var frametimeSubset = GetFrametimesSubset();
-            var sampleSubset = _appConfiguration.UseDisplayChangeMetrics
-                ? GetDisplayChangeTimesSubset() : frametimeSubset;
+            var sampleSubset = GetMetricSamplesSubset(frametimeSubset);
             var gpuActiveSubset = GetGpuActiveTimesSubset();
 
             if (frametimeSubset != null && sampleSubset != null)
             {
                 _onUpdateChart.OnNext(default);
 
-                Task.Factory.StartNew(() => SetStaticChart(frametimeSubset, sampleSubset, gpuActiveSubset));
-                Task.Factory.StartNew(() => SetStutteringChart(sampleSubset));
-                Task.Factory.StartNew(() => SetVarianceChart());
-                Task.Factory.StartNew(() => SetFpsThresholdChart(sampleSubset));
+                Task.Run(() =>
+                {
+                    SetStaticChart(frametimeSubset, sampleSubset, gpuActiveSubset, updateVersion, cancellationToken);
+                    SetStutteringChart(sampleSubset, updateVersion, cancellationToken);
+                    SetVarianceChart(sampleSubset, updateVersion, cancellationToken);
+                    SetFpsThresholdChart(sampleSubset, updateVersion, cancellationToken);
+                }, cancellationToken);
             }
         }
 
         private void RealTimeUpdateCharts()
         {
             if (!_doUpdateCharts) return;
+            BeginAnalysisUpdate(out _);
             _onUpdateChart.OnNext(default);
         }
 
         private void DemandUpdateCharts()
         {
+            var cancellationToken = BeginAnalysisUpdate(out int updateVersion);
             if (!_doUpdateCharts)
                 return;
 
             var frametimeSubset = GetFrametimesSubset();
-            var sampleSubset = _appConfiguration.UseDisplayChangeMetrics
-                ? GetDisplayChangeTimesSubset() : frametimeSubset;
+            var sampleSubset = GetMetricSamplesSubset(frametimeSubset);
             var gpuActiveSubset = GetGpuActiveTimesSubset();
 
             if (frametimeSubset != null && sampleSubset != null)
             {
-                Task.Factory.StartNew(() => SetStaticChart(frametimeSubset, sampleSubset, gpuActiveSubset));
-                Task.Factory.StartNew(() => SetStutteringChart(sampleSubset));
-                Task.Factory.StartNew(() => SetVarianceChart());
-                Task.Factory.StartNew(() => SetFpsThresholdChart(sampleSubset));
+                Task.Run(() =>
+                {
+                    SetStaticChart(frametimeSubset, sampleSubset, gpuActiveSubset, updateVersion, cancellationToken);
+                    SetStutteringChart(sampleSubset, updateVersion, cancellationToken);
+                    SetVarianceChart(sampleSubset, updateVersion, cancellationToken);
+                    SetFpsThresholdChart(sampleSubset, updateVersion, cancellationToken);
+                }, cancellationToken);
                 UpdateSensorSessionReport();
             }
         }
 
         private void UpdateSecondaryCharts()
         {
+            var cancellationToken = BeginUpdate(ref _secondaryChartUpdateVersion,
+                ref _secondaryChartUpdateCancellation, out int updateVersion);
             if (SelectedChartItem == null)
                 return;
 
             var headerName = SelectedChartItem.Header.ToString();
             var frametimeSubset = GetFrametimesSubset();
-            var sampleSubset = _appConfiguration.UseDisplayChangeMetrics
-               ? GetDisplayChangeTimesSubset() : frametimeSubset;
+            var sampleSubset = GetMetricSamplesSubset(frametimeSubset);
             var fpsSubset = GetFPSSubset();
 
             if (sampleSubset == null || fpsSubset == null)
@@ -1514,7 +1614,7 @@ namespace CapFrameX.ViewModel
 
             if (headerName.Contains("L-shape"))
             {
-                Task.Factory.StartNew(() => SetLShapeChart(sampleSubset, fpsSubset));
+                Task.Run(() => SetLShapeChart(sampleSubset, fpsSubset, updateVersion, cancellationToken), cancellationToken);
             }
         }
 
@@ -1523,6 +1623,18 @@ namespace CapFrameX.ViewModel
 
         private IList<double> GetDisplayChangeTimesSubset()
             => _localRecordDataServer?.GetDisplayChangeTimeWindow();
+
+        private IList<double> GetMetricSamplesSubset(IList<double> frametimes = null)
+        {
+            if (_appConfiguration.UseDisplayChangeMetrics)
+            {
+                var displayTimes = GetDisplayChangeTimesSubset();
+                if (displayTimes != null && displayTimes.Any())
+                    return displayTimes;
+            }
+
+            return frametimes ?? GetFrametimesSubset();
+        }
 
         private IList<double> GetFPSSubset()
             => _localRecordDataServer?.GetFpsTimeWindow();
@@ -1536,25 +1648,44 @@ namespace CapFrameX.ViewModel
         private IList<double> GetGpuActiveFPSSubset()
             => _localRecordDataServer?.GetGpuActiveFpsTimeWindow();
 
-        private void SetStaticChart(IList<double> frametimes, IList<double> displayChangeTimes, IList<double> gpuActiveTimes)
+        private void SetStaticChart(IList<double> frametimes, IList<double> displayChangeTimes,
+            IList<double> gpuActiveTimes, int updateVersion, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested || !IsCurrentAnalysisUpdate(updateVersion))
+                return;
             if (frametimes == null || !frametimes.Any())
                 return;
 
             if (displayChangeTimes == null || !displayChangeTimes.Any())
                 return;
 
-            var animationErrorsAbs = GetAnimationErrorsSubset()?.Select(error => Math.Abs(error)).ToList();
-
-            double GetFrametimeMetricValue(IList<double> sequence, EMetric metric) =>
-                _frametimeStatisticProvider.GetFrametimeMetricValue(sequence, metric);
+            var animationErrorsAbs = GetAnimationErrorsSubset()?
+                .Where(IsFinite)
+                .Select(error => Math.Abs(error))
+                .ToList();
+            cancellationToken.ThrowIfCancellationRequested();
 
             double GetP99MetricValue(IList<double> sequence) =>
                 Math.Round(_frametimeStatisticProvider.GetPQuantileSequence(sequence, 0.99),
                     _appConfiguration.FpsValuesRoundingDigits, MidpointRounding.AwayFromZero);
 
-            double GetMetricValue(IList<double> sequence, EMetric metric) =>
-                _frametimeStatisticProvider.GetFpsMetricValue(sequence, metric);
+            var requestedMetrics = new[]
+            {
+                EMetric.Max,
+                EMetric.P99,
+                EMetric.P95,
+                EMetric.Median,
+                EMetric.P0dot1,
+                EMetric.P0dot2,
+                EMetric.P1,
+                EMetric.P5,
+                EMetric.OnePercentLowAverage,
+                EMetric.ZerodotOnePercentLowAverage,
+                EMetric.OnePercentLowIntegral,
+                EMetric.ZerodotOnePercentLowIntegral,
+                EMetric.Min,
+                EMetric.AdaptiveStd
+            };
 
             var max = double.NaN;
             var p99_quantile = double.NaN;
@@ -1581,55 +1712,65 @@ namespace CapFrameX.ViewModel
 
             if (UseFrametimeStatisticParameters)
             {
-                max = GetFrametimeMetricValue(displayChangeTimes, EMetric.Max);
-                p99_quantile = GetFrametimeMetricValue(displayChangeTimes, EMetric.P99);
-                p95_quantile = GetFrametimeMetricValue(displayChangeTimes, EMetric.P95);
-                median = GetFrametimeMetricValue(displayChangeTimes, EMetric.Median);
-                average = GetFrametimeMetricValue(frametimes, EMetric.Average);
-                gpuActiveAverage = !gpuActiveTimes.IsNullOrEmpty() ? GetFrametimeMetricValue(gpuActiveTimes, EMetric.GpuActiveAverage) : double.NaN;
-                p0dot1_quantile = GetFrametimeMetricValue(displayChangeTimes, EMetric.P0dot1);
-                p0dot2_quantile = GetFrametimeMetricValue(displayChangeTimes, EMetric.P0dot2);
-                p1_quantile = GetFrametimeMetricValue(displayChangeTimes, EMetric.P1);
-                gpuActiveP1_quantile = !gpuActiveTimes.IsNullOrEmpty() ? GetFrametimeMetricValue(gpuActiveTimes, EMetric.GpuActiveP1) : double.NaN;
-                p5_quantile = GetFrametimeMetricValue(displayChangeTimes, EMetric.P5);
-                p1_LowAverage = GetFrametimeMetricValue(displayChangeTimes, EMetric.OnePercentLowAverage);
-                gpuActiveP1_LowAverage = !gpuActiveTimes.IsNullOrEmpty() ? GetFrametimeMetricValue(gpuActiveTimes, EMetric.GpuActiveOnePercentLowAverage) : double.NaN;
-                p0dot1_LowAverage = GetFrametimeMetricValue(displayChangeTimes, EMetric.ZerodotOnePercentLowAverage);
-                p1_LowIntegral = GetFrametimeMetricValue(displayChangeTimes, EMetric.OnePercentLowIntegral);
-                p0dot1_LowIntegral = GetFrametimeMetricValue(displayChangeTimes, EMetric.ZerodotOnePercentLowIntegral);
-                min = GetFrametimeMetricValue(displayChangeTimes, EMetric.Min);
-                adaptiveStandardDeviation = GetFrametimeMetricValue(displayChangeTimes, EMetric.AdaptiveStd);
+                var metricValues = _frametimeStatisticProvider.GetFrametimeMetricValues(displayChangeTimes, requestedMetrics);
+                cancellationToken.ThrowIfCancellationRequested();
+                max = metricValues[EMetric.Max];
+                p99_quantile = metricValues[EMetric.P99];
+                p95_quantile = metricValues[EMetric.P95];
+                median = metricValues[EMetric.Median];
+                average = _frametimeStatisticProvider.GetFrametimeMetricValue(frametimes, EMetric.Average);
+                p0dot1_quantile = metricValues[EMetric.P0dot1];
+                p0dot2_quantile = metricValues[EMetric.P0dot2];
+                p1_quantile = metricValues[EMetric.P1];
+                p5_quantile = metricValues[EMetric.P5];
+                p1_LowAverage = metricValues[EMetric.OnePercentLowAverage];
+                p0dot1_LowAverage = metricValues[EMetric.ZerodotOnePercentLowAverage];
+                p1_LowIntegral = metricValues[EMetric.OnePercentLowIntegral];
+                p0dot1_LowIntegral = metricValues[EMetric.ZerodotOnePercentLowIntegral];
+                min = metricValues[EMetric.Min];
+                adaptiveStandardDeviation = metricValues[EMetric.AdaptiveStd];
+
+                if (!gpuActiveTimes.IsNullOrEmpty())
+                {
+                    var gpuActiveMetricValues = _frametimeStatisticProvider.GetFrametimeMetricValues(gpuActiveTimes,
+                        new[] { EMetric.GpuActiveAverage, EMetric.GpuActiveP1, EMetric.GpuActiveOnePercentLowAverage });
+                    cancellationToken.ThrowIfCancellationRequested();
+                    gpuActiveAverage = gpuActiveMetricValues[EMetric.GpuActiveAverage];
+                    gpuActiveP1_quantile = gpuActiveMetricValues[EMetric.GpuActiveP1];
+                    gpuActiveP1_LowAverage = gpuActiveMetricValues[EMetric.GpuActiveOnePercentLowAverage];
+                }
 
                 if (!animationErrorsAbs.IsNullOrEmpty())
                 {
-                    animationErrorAverage = GetFrametimeMetricValue(animationErrorsAbs, EMetric.Average);
+                    animationErrorAverage = _frametimeStatisticProvider.GetFrametimeMetricValue(animationErrorsAbs, EMetric.Average);
                     animationErrorP99 = GetP99MetricValue(animationErrorsAbs);
+                    cancellationToken.ThrowIfCancellationRequested();
                 }
             }
             else
             {
-                max = GetMetricValue(displayChangeTimes, EMetric.Max);
-                p99_quantile = GetMetricValue(displayChangeTimes, EMetric.P99);
-                p95_quantile = GetMetricValue(displayChangeTimes, EMetric.P95);
-                median = GetMetricValue(displayChangeTimes, EMetric.Median);
-                average = GetMetricValue(frametimes, EMetric.Average);
-                //gpuActiveAverage = !gpuActiveTimes.IsNullOrEmpty() ? GetMetricValue(gpuActiveTimes, EMetric.GpuActiveAverage) : double.NaN;
-                p0dot1_quantile = GetMetricValue(displayChangeTimes, EMetric.P0dot1);
-                p0dot2_quantile = GetMetricValue(displayChangeTimes, EMetric.P0dot2);
-                p1_quantile = GetMetricValue(displayChangeTimes, EMetric.P1);
-                //gpuActiveP1_quantile = !gpuActiveTimes.IsNullOrEmpty() ? GetMetricValue(gpuActiveTimes, EMetric.GpuActiveP1) : double.NaN;
-                p5_quantile = GetMetricValue(displayChangeTimes, EMetric.P5);
-                p1_LowAverage = GetMetricValue(displayChangeTimes, EMetric.OnePercentLowAverage);
-                //gpuActiveP1_LowAverage = !gpuActiveTimes.IsNullOrEmpty() ? GetMetricValue(gpuActiveTimes, EMetric.GpuActiveOnePercentLowAverage) : double.NaN;
-                p0dot1_LowAverage = GetMetricValue(displayChangeTimes, EMetric.ZerodotOnePercentLowAverage);
-                p1_LowIntegral = GetMetricValue(displayChangeTimes, EMetric.OnePercentLowIntegral);
-                p0dot1_LowIntegral = GetMetricValue(displayChangeTimes, EMetric.ZerodotOnePercentLowIntegral);
-                min = GetMetricValue(displayChangeTimes, EMetric.Min);
-                adaptiveStandardDeviation = GetMetricValue(displayChangeTimes, EMetric.AdaptiveStd);
+                var metricValues = _frametimeStatisticProvider.GetFpsMetricValues(displayChangeTimes, requestedMetrics);
+                cancellationToken.ThrowIfCancellationRequested();
+                max = metricValues[EMetric.Max];
+                p99_quantile = metricValues[EMetric.P99];
+                p95_quantile = metricValues[EMetric.P95];
+                median = metricValues[EMetric.Median];
+                average = _frametimeStatisticProvider.GetFpsMetricValue(frametimes, EMetric.Average);
+                p0dot1_quantile = metricValues[EMetric.P0dot1];
+                p0dot2_quantile = metricValues[EMetric.P0dot2];
+                p1_quantile = metricValues[EMetric.P1];
+                p5_quantile = metricValues[EMetric.P5];
+                p1_LowAverage = metricValues[EMetric.OnePercentLowAverage];
+                p0dot1_LowAverage = metricValues[EMetric.ZerodotOnePercentLowAverage];
+                p1_LowIntegral = metricValues[EMetric.OnePercentLowIntegral];
+                p0dot1_LowIntegral = metricValues[EMetric.ZerodotOnePercentLowIntegral];
+                min = metricValues[EMetric.Min];
+                adaptiveStandardDeviation = metricValues[EMetric.AdaptiveStd];
                 cpuFpsPerWatt = _frametimeStatisticProvider
                     .GetPhysicalMetricValue(frametimes, EMetric.CpuFpsPerWatt,
                     SensorReport.GetAverageSensorValues(_session.Runs.Select(run => run.SensorData2), EReportSensorName.CpuPower,
                     _localRecordDataServer.CurrentTime, _localRecordDataServer.CurrentTime + _localRecordDataServer.WindowLength));
+                cancellationToken.ThrowIfCancellationRequested();
                 gpuFpsPerWatt = _frametimeStatisticProvider
                 .GetPhysicalMetricValue(frametimes, EMetric.GpuFpsPerWatt,
                 SensorReport.GetAverageSensorValues(_session.Runs.Select(run => run.SensorData2), EReportSensorName.GpuPower,
@@ -1637,8 +1778,12 @@ namespace CapFrameX.ViewModel
             }
 
             // set metrics
+            cancellationToken.ThrowIfCancellationRequested();
             Application.Current.Dispatcher.Invoke(new Action(() =>
             {
+                if (cancellationToken.IsCancellationRequested || !IsCurrentAnalysisUpdate(updateVersion))
+                    return;
+
                 IChartValues values = new ChartValues<double>();
                 if (UseFrametimeStatisticParameters)
                 {
@@ -1846,21 +1991,29 @@ namespace CapFrameX.ViewModel
             }));
         }
 
-        private void SetStutteringChart(IList<double> samples)
+        private void SetStutteringChart(IList<double> samples, int updateVersion, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested || !IsCurrentAnalysisUpdate(updateVersion))
+                return;
             if (samples == null || !samples.Any())
                 return;
 
             var stutteringTimePercentage = _frametimeStatisticProvider.GetStutteringTimePercentage(samples, _appConfiguration.StutteringFactor);
+            cancellationToken.ThrowIfCancellationRequested();
 
             var lowFPSTimePercentage = _frametimeStatisticProvider.GetLowFPSTimePercentage(samples, _appConfiguration.StutteringFactor, _appConfiguration.StutteringThreshold);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            double stutteringTotalTime = Math.Round(stutteringTimePercentage / 100 * samples.Skip(1).Sum() / 1000, 2, MidpointRounding.AwayFromZero);
-            double lowFPSTotalTime = Math.Round(lowFPSTimePercentage / 100 * samples.Skip(1).Sum() / 1000, 2, MidpointRounding.AwayFromZero);
-            double smoothTotalTime = Math.Round((1 - (stutteringTimePercentage + lowFPSTimePercentage) / 100) * samples.Skip(1).Sum() / 1000, 2, MidpointRounding.AwayFromZero);
+            var totalSampleTime = samples.Sum() / 1000;
+            double stutteringTotalTime = Math.Round(stutteringTimePercentage / 100 * totalSampleTime, 2, MidpointRounding.AwayFromZero);
+            double lowFPSTotalTime = Math.Round(lowFPSTimePercentage / 100 * totalSampleTime, 2, MidpointRounding.AwayFromZero);
+            double smoothTotalTime = Math.Round((1 - (stutteringTimePercentage + lowFPSTimePercentage) / 100) * totalSampleTime, 2, MidpointRounding.AwayFromZero);
 
             Application.Current.Dispatcher.BeginInvoke(new Action(() =>
             {
+                if (cancellationToken.IsCancellationRequested || !IsCurrentAnalysisUpdate(updateVersion))
+                    return;
+
                 StutteringStatisticCollection = new SeriesCollection
                 {
                     new PieSeries
@@ -1893,23 +2046,21 @@ namespace CapFrameX.ViewModel
             }));
         }
 
-        private void SetVarianceChart()
+        private void SetVarianceChart(IList<double> samples, int updateVersion, CancellationToken cancellationToken)
         {
-            if (_session == null) return;
+            if (cancellationToken.IsCancellationRequested || !IsCurrentAnalysisUpdate(updateVersion))
+                return;
+            if (samples == null)
+                return;
 
-            IList<double> variances;
-
-            if (_appConfiguration.UseDisplayChangeMetrics)
-            {
-                variances = _frametimeStatisticProvider.GetDisplayTimeVariancePercentages(_session);
-            }
-            else
-            {
-                variances = _frametimeStatisticProvider.GetFrametimeVariancePercentages(_session);
-            }
+            var variances = _frametimeStatisticProvider.GetVariancePercentages(samples);
+            cancellationToken.ThrowIfCancellationRequested();
 
             Application.Current.Dispatcher.BeginInvoke(new Action(() =>
             {
+                if (cancellationToken.IsCancellationRequested || !IsCurrentAnalysisUpdate(updateVersion))
+                    return;
+
                 VarianceStatisticCollection = new SeriesCollection
                 {
                     new PieSeries
@@ -1960,21 +2111,30 @@ namespace CapFrameX.ViewModel
             }));
         }
 
-        private void SetLShapeChart(IList<double> samples, IList<double> fps)
+        private void SetLShapeChart(IList<double> samples, IList<double> fps, int updateVersion,
+            CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested || Volatile.Read(ref _secondaryChartUpdateVersion) != updateVersion)
+                return;
             if (samples == null || !samples.Any())
                 return;
 
             var lShapeQuantiles = _frametimeAnalyzer.GetLShapeQuantiles(SelectedLShapeMetric);
             double action(double q) => _frametimeStatisticProvider.GetPQuantileSequence(SelectedLShapeMetric == ELShapeMetrics.Frametimes ? samples : fps, q / 100);
-            var observablePoints = lShapeQuantiles.Select(q => new ObservablePoint(q, action(q)));
-
             var chartValues = new ChartValues<ObservablePoint>();
-            chartValues.AddRange(observablePoints);
+            foreach (var quantile in lShapeQuantiles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                chartValues.Add(new ObservablePoint(quantile, action(quantile)));
+            }
             string unit = SelectedLShapeMetric == ELShapeMetrics.Frametimes ? " ms" : " fps";
 
             Application.Current.Dispatcher.BeginInvoke(new Action(() =>
             {
+                if (cancellationToken.IsCancellationRequested
+                    || Volatile.Read(ref _secondaryChartUpdateVersion) != updateVersion)
+                    return;
+
                 LShapeCollection = new SeriesCollection()
                 {
                     new LineSeries
@@ -2031,69 +2191,102 @@ namespace CapFrameX.ViewModel
             {
                 case EChartYAxisSetting.FullFit:
                     {
-                        var frametimes = _localRecordDataServer?
-                            .GetFrametimePointTimeWindow().Select(pnt => pnt.Y);
+                        var frametimes = _localRecordDataServer
+                            .GetFrametimePointTimeWindow()
+                            .Select(point => point.Y)
+                            .Where(IsFinite)
+                            .ToList();
+                        if (!frametimes.Any())
+                            return setting;
 
-                        var yMin = frametimes.Min();
-                        var yMax = frametimes.Max();
+                        var chartTimes = frametimes;
+                        if (_appConfiguration.UseDisplayChangeMetrics)
+                        {
+                            var displayTimes = (GetDisplayChangeTimesSubset() ?? new List<double>())
+                                .Where(IsFinite)
+                                .ToList();
+                            if (displayTimes.Any())
+                                chartTimes = frametimes.Concat(displayTimes).ToList();
+                        }
 
+                        var yMin = chartTimes.Min();
+                        var yMax = chartTimes.Max();
 
                         if (GetIsGpuActiveChartAvailable() && ShowGpuActiveChart)
                         {
-                            var gpuActiveTimes = _localRecordDataServer?
-                            .GetGpuActiveTimePointTimeWindow().Select(pnt => pnt.Y);
-
-                            yMin = Math.Min(yMin, gpuActiveTimes.Min());
-                            yMax = Math.Max(yMax, gpuActiveTimes.Max());
+                            var gpuActiveTimes = _localRecordDataServer
+                                .GetGpuActiveTimePointTimeWindow()
+                                .Select(point => point.Y)
+                                .Where(IsFinite)
+                                .ToList();
+                            if (gpuActiveTimes.Any())
+                            {
+                                yMin = Math.Min(yMin, gpuActiveTimes.Min());
+                                yMax = Math.Max(yMax, gpuActiveTimes.Max());
+                            }
                         }
 
                         if (GetIsCpuActiveChartAvailable() && ShowCpuActiveChart)
                         {
-                            var cpuActiveTimes = _localRecordDataServer?
-                            .GetCpuActiveTimePointTimeWindow().Select(pnt => pnt.Y);
-
-                            yMin = Math.Min(yMin, cpuActiveTimes.Min());
-                            yMax = Math.Max(yMax, cpuActiveTimes.Max());
+                            var cpuActiveTimes = _localRecordDataServer
+                                .GetCpuActiveTimePointTimeWindow()
+                                .Select(point => point.Y)
+                                .Where(IsFinite)
+                                .ToList();
+                            if (cpuActiveTimes.Any())
+                            {
+                                yMin = Math.Min(yMin, cpuActiveTimes.Min());
+                                yMax = Math.Max(yMax, cpuActiveTimes.Max());
+                            }
                         }
 
                         if (ShowStutteringThresholds)
                         {
                             var frametimeStatisticProvider = new FrametimeStatisticProvider(null);
-                            var sampleSubset = _appConfiguration.UseDisplayChangeMetrics
-                                ? GetDisplayChangeTimesSubset() : frametimes;
+                            var sampleSubset = GetMetricSamplesSubset(frametimes);
 
-                            var movingAverage = frametimeStatisticProvider.GetMovingAverage(sampleSubset.ToList());
-
-                            yMax = Math.Max(Math.Max(movingAverage.Max() * _appConfiguration.StutteringFactor, yMax), 1000 / _appConfiguration.StutteringThreshold);
+                            var movingAverage = frametimeStatisticProvider.GetMovingAverage(sampleSubset);
+                            if (movingAverage.Any())
+                            {
+                                yMax = Math.Max(Math.Max(movingAverage.Max() * _appConfiguration.StutteringFactor, yMax),
+                                    1000 / _appConfiguration.StutteringThreshold);
+                            }
                         }
 
                         if (IsPcLatencyAvailable && ShowPcLatency)
                         {
-                            var maxLatency = _localRecordDataServer.CurrentSession.Runs.Max(run => run.CaptureData.PcLatency.Max());
-                            yMax = Math.Max(yMax, maxLatency);
+                            yMax = Math.Max(yMax, GetPcLatencyMaximum());
                         }
 
                         if (IsAnimationErrorAvailable && ShowAnimationError)
                         {
-                            var minAnimationError = _localRecordDataServer.CurrentSession.Runs.Max(run =>
-                                run.CaptureData.AnimationError.Where(x => !double.IsNaN(x)).DefaultIfEmpty(0).Min());
-                            var maxAnimationError = _localRecordDataServer.CurrentSession.Runs.Max(run =>
-                                run.CaptureData.AnimationError.Where(x => !double.IsNaN(x)).DefaultIfEmpty(0).Max());
-                            yMin = Math.Min(yMin, minAnimationError);
-                            yMax = Math.Max(yMax, maxAnimationError);
+                            var animationErrorBounds = GetAnimationErrorBounds();
+                            yMin = Math.Min(yMin, animationErrorBounds.Min);
+                            yMax = Math.Max(yMax, animationErrorBounds.Max);
                         }
 
-                        setting = new Tuple<double, double>(yMin - (yMax - yMin) / 6, yMax + (yMax - yMin) / 6);
+                        var padding = yMax > yMin
+                            ? (yMax - yMin) / 6
+                            : Math.Max(Math.Abs(yMax) / 10, 1);
+                        setting = new Tuple<double, double>(yMin - padding, yMax + padding);
                     }
                     break;
                 case EChartYAxisSetting.IQR:
                     {
-                        double iqr = MathNet.Numerics.Statistics.Statistics
-                            .InterquartileRange(_localRecordDataServer?
-                            .GetFrametimePointTimeWindow().Select(pnt => pnt.Y));
-                        double median = MathNet.Numerics.Statistics.Statistics
-                            .Median(_localRecordDataServer?
-                            .GetFrametimePointTimeWindow().Select(pnt => pnt.Y));
+                        var chartTimes = _localRecordDataServer
+                            .GetFrametimePointTimeWindow()
+                            .Select(point => point.Y)
+                            .Where(IsFinite)
+                            .ToList();
+                        if (_appConfiguration.UseDisplayChangeMetrics)
+                        {
+                            chartTimes.AddRange((GetDisplayChangeTimesSubset() ?? new List<double>()).Where(IsFinite));
+                        }
+                        if (!chartTimes.Any())
+                            return setting;
+
+                        double iqr = MathNet.Numerics.Statistics.Statistics.InterquartileRange(chartTimes);
+                        double median = MathNet.Numerics.Statistics.Statistics.Median(chartTimes);
 
                         double gpuActiveIqr = double.MinValue;
                         double gpuActiveMedian = double.MinValue;
@@ -2102,22 +2295,30 @@ namespace CapFrameX.ViewModel
 
                         if (GetIsGpuActiveChartAvailable() && ShowGpuActiveChart)
                         {
-                            gpuActiveIqr = MathNet.Numerics.Statistics.Statistics
-                                .InterquartileRange(_localRecordDataServer?
-                                .GetGpuActiveTimePointTimeWindow().Select(pnt => pnt.Y));
-                            gpuActiveMedian = MathNet.Numerics.Statistics.Statistics
-                                .Median(_localRecordDataServer?
-                                .GetGpuActiveTimePointTimeWindow().Select(pnt => pnt.Y));
+                            var gpuActiveTimes = _localRecordDataServer
+                                .GetGpuActiveTimePointTimeWindow()
+                                .Select(point => point.Y)
+                                .Where(IsFinite)
+                                .ToList();
+                            if (gpuActiveTimes.Any())
+                            {
+                                gpuActiveIqr = MathNet.Numerics.Statistics.Statistics.InterquartileRange(gpuActiveTimes);
+                                gpuActiveMedian = MathNet.Numerics.Statistics.Statistics.Median(gpuActiveTimes);
+                            }
                         }
 
                         if (GetIsCpuActiveChartAvailable() && ShowCpuActiveChart)
                         {
-                            cpuActiveIqr = MathNet.Numerics.Statistics.Statistics
-                                .InterquartileRange(_localRecordDataServer?
-                                .GetCpuActiveTimePointTimeWindow().Select(pnt => pnt.Y));
-                            cpuActiveMedian = MathNet.Numerics.Statistics.Statistics
-                                .Median(_localRecordDataServer?
-                                .GetCpuActiveTimePointTimeWindow().Select(pnt => pnt.Y));
+                            var cpuActiveTimes = _localRecordDataServer
+                                .GetCpuActiveTimePointTimeWindow()
+                                .Select(point => point.Y)
+                                .Where(IsFinite)
+                                .ToList();
+                            if (cpuActiveTimes.Any())
+                            {
+                                cpuActiveIqr = MathNet.Numerics.Statistics.Statistics.InterquartileRange(cpuActiveTimes);
+                                cpuActiveMedian = MathNet.Numerics.Statistics.Statistics.Median(cpuActiveTimes);
+                            }
                         }
 
                         double maxMedian = Math.Max(Math.Max(median, gpuActiveMedian), cpuActiveMedian);
@@ -2161,11 +2362,64 @@ namespace CapFrameX.ViewModel
                 || _localRecordDataServer?.CurrentSession == null)
                 return (double.PositiveInfinity, double.NegativeInfinity);
 
-            var min = _localRecordDataServer.CurrentSession.Runs.Min(run =>
-                run.CaptureData.AnimationError.Where(x => !double.IsNaN(x)).DefaultIfEmpty(0).Min());
-            var max = _localRecordDataServer.CurrentSession.Runs.Max(run =>
-                run.CaptureData.AnimationError.Where(x => !double.IsNaN(x)).DefaultIfEmpty(0).Max());
-            return (min, max);
+            var values = (GetAnimationErrorsSubset() ?? new List<double>())
+                .Where(IsFinite)
+                .ToList();
+            return values.Any()
+                ? (values.Min(), values.Max())
+                : (double.PositiveInfinity, double.NegativeInfinity);
+        }
+
+        private double GetPcLatencyMaximum()
+        {
+            var startTime = _localRecordDataServer.CurrentTime;
+            var endTime = startTime + _localRecordDataServer.WindowLength;
+            return _localRecordDataServer.CurrentSession
+                .GetPcLatencyPointTimeWindow()
+                .Where(point => point.X >= startTime && point.X <= endTime && IsFinite(point.Y) && point.Y > 0)
+                .Select(point => point.Y)
+                .DefaultIfEmpty(double.NegativeInfinity)
+                .Max();
+        }
+
+        private static bool IsFinite(double value)
+            => !double.IsNaN(value) && !double.IsInfinity(value);
+
+        private bool IsCurrentAnalysisUpdate(int updateVersion)
+            => Volatile.Read(ref _analysisUpdateVersion) == updateVersion;
+
+        private CancellationToken BeginAnalysisUpdate(out int updateVersion)
+        {
+            var token = BeginUpdate(ref _analysisUpdateVersion, ref _analysisUpdateCancellation, out updateVersion);
+            CancelUpdate(ref _thresholdUpdateVersion, ref _thresholdUpdateCancellation);
+            return token;
+        }
+
+        private CancellationToken BeginThresholdUpdate(out int updateVersion)
+            => BeginUpdate(ref _thresholdUpdateVersion, ref _thresholdUpdateCancellation, out updateVersion);
+
+        private bool IsCurrentThresholdUpdate(int updateVersion)
+            => Volatile.Read(ref _thresholdUpdateVersion) == updateVersion;
+
+        private static CancellationToken BeginUpdate(ref int updateVersion,
+            ref CancellationTokenSource cancellationSource, out int newVersion)
+        {
+            newVersion = Interlocked.Increment(ref updateVersion);
+            var newSource = new CancellationTokenSource();
+            var previousSource = Interlocked.Exchange(ref cancellationSource, newSource);
+            previousSource?.Cancel();
+            previousSource?.Dispose();
+            return newSource.Token;
+        }
+
+        private static void CancelUpdate(ref int updateVersion,
+            ref CancellationTokenSource cancellationSource)
+        {
+            Interlocked.Increment(ref updateVersion);
+            var replacement = new CancellationTokenSource();
+            var previousSource = Interlocked.Exchange(ref cancellationSource, replacement);
+            previousSource?.Cancel();
+            previousSource?.Dispose();
         }
 
         private void SetChartUpdateFlags(bool frametimes = true, bool fps = true, bool distribution = true)

--- a/source/CapFrameX.ViewModel/ReportViewModel.cs
+++ b/source/CapFrameX.ViewModel/ReportViewModel.cs
@@ -305,9 +305,15 @@ namespace CapFrameX.ViewModel
                 sequence.Any()
                     ? Math.Round(sequence.Average(), _appConfiguration.FpsValuesRoundingDigits, MidpointRounding.AwayFromZero)
                     : double.NaN;
-            var frameTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToList();
-            var displayTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToList();
-            var samples = _appConfiguration.UseDisplayChangeMetrics ? displayTimes : frameTimes;
+            var frameTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents)
+                .Where(time => time > 0 && !double.IsNaN(time) && !double.IsInfinity(time))
+                .ToList();
+            var displayTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange)
+                .Where(time => time > 0 && !double.IsNaN(time) && !double.IsInfinity(time))
+                .ToList();
+            var samples = _appConfiguration.UseDisplayChangeMetrics && displayTimes.Any()
+                ? displayTimes
+                : frameTimes;
 
             var GpuActiveTimes = session.Runs.SelectMany(r => r.CaptureData.GpuActive).ToList();
             var animationErrorsAbs = session.Runs

--- a/source/CapFrameX.ViewModel/SynchronizationViewModel.cs
+++ b/source/CapFrameX.ViewModel/SynchronizationViewModel.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -64,6 +65,8 @@ namespace CapFrameX.ViewModel
         private int _inputLagBarMaxValue = 100;
         private Func<double, string> _inputLagParameterFormatter;
         private string[] _inputLagParameterLabels;
+        private int _chartUpdateVersion;
+        private CancellationTokenSource _chartUpdateCancellation = new CancellationTokenSource();
 
         /// <summary>
         /// https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings
@@ -388,31 +391,51 @@ namespace CapFrameX.ViewModel
 
         private void UpdateCharts()
         {
-            if (_session == null)
+            int updateVersion = Interlocked.Increment(ref _chartUpdateVersion);
+            var newCancellation = new CancellationTokenSource();
+            var previousCancellation = Interlocked.Exchange(ref _chartUpdateCancellation, newCancellation);
+            previousCancellation?.Cancel();
+            previousCancellation?.Dispose();
+            var cancellationToken = newCancellation.Token;
+            var session = _session;
+            if (session == null)
                 return;
 
-            // Do not run on background thread, leads to errors on analysis page
-            var inputLagTimes = _session.CalculateInputLagTimes(EInputLagType.Expected).Select(val => val += InputLagOffset).ToList();
-            var upperBoundInputLagTimes = _session.CalculateInputLagTimes(EInputLagType.UpperBound).Select(val => val += InputLagOffset).ToList();
-            var lowerBoundInputLagTimes = _session.CalculateInputLagTimes(EInputLagType.LowerBound).Select(val => val += InputLagOffset).ToList();
-            var frametimes = _session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToList();
-            var displayTimes = _session.Runs.SelectMany(r => r.CaptureData.MsUntilDisplayed).ToList();
-            var appMissed = _session.Runs.SelectMany(r => r.CaptureData.Dropped).ToList();
+            int inputLagOffset = InputLagOffset;
+            Task.Run(() =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var inputLagTimes = session.CalculateInputLagTimes(EInputLagType.Expected).Select(val => val + inputLagOffset).ToList();
+                cancellationToken.ThrowIfCancellationRequested();
+                var upperBoundInputLagTimes = session.CalculateInputLagTimes(EInputLagType.UpperBound).Select(val => val + inputLagOffset).ToList();
+                cancellationToken.ThrowIfCancellationRequested();
+                var lowerBoundInputLagTimes = session.CalculateInputLagTimes(EInputLagType.LowerBound).Select(val => val + inputLagOffset).ToList();
+                cancellationToken.ThrowIfCancellationRequested();
+                var frametimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToList();
+                var displayTimes = session.Runs.SelectMany(r => r.CaptureData.MsUntilDisplayed).ToList();
+                var appMissed = session.Runs.SelectMany(r => r.CaptureData.Dropped).ToList();
 
-            SetFrameDisplayTimesChart(frametimes, displayTimes);
-            SetFrameInputLagChart(frametimes, upperBoundInputLagTimes, lowerBoundInputLagTimes);
-            Task.Factory.StartNew(() => SetDisplayTimesHistogramChart(displayTimes));
-            Task.Factory.StartNew(() => SetInputLagHistogramChart(inputLagTimes.Where(t => !double.IsNaN(t)).ToList()));
-            Task.Factory.StartNew(() => SetInputLagStatisticChart(
-                inputLagTimes.Where(t => !double.IsNaN(t)).ToList(),
-                upperBoundInputLagTimes.Where(t => !double.IsNaN(t)).ToList(), 
-                lowerBoundInputLagTimes.Where(t => !double.IsNaN(t)).ToList())
-            );
-            Task.Factory.StartNew(() => SetDroppedFramesChart(appMissed));
+                if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion))
+                    return;
+
+                var validInputLagTimes = FilterFiniteValues(inputLagTimes, cancellationToken);
+                var validUpperBounds = FilterFiniteValues(upperBoundInputLagTimes, cancellationToken);
+                var validLowerBounds = FilterFiniteValues(lowerBoundInputLagTimes, cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+                SetFrameDisplayTimesChart(frametimes, displayTimes, updateVersion, cancellationToken);
+                SetFrameInputLagChart(frametimes, upperBoundInputLagTimes, lowerBoundInputLagTimes,
+                    appMissed, updateVersion, cancellationToken);
+                SetDisplayTimesHistogramChart(displayTimes, updateVersion, cancellationToken);
+                SetInputLagHistogramChart(validInputLagTimes, updateVersion, cancellationToken);
+                SetInputLagStatisticChart(validInputLagTimes, validUpperBounds, validLowerBounds, updateVersion, cancellationToken);
+                SetDroppedFramesChart(appMissed, updateVersion, cancellationToken);
+            }, cancellationToken);
         }
 
-        private void SetFrameDisplayTimesChart(IList<double> frametimes, IList<double> displaytimes)
+        private void SetFrameDisplayTimesChart(IList<double> frametimes, IList<double> displaytimes, int updateVersion,
+            CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
             if (frametimes == null || !frametimes.Any())
                 return;
 
@@ -442,11 +465,21 @@ namespace CapFrameX.ViewModel
                 EdgeRenderingMode = EdgeRenderingMode.PreferSpeed
             };
 
-            frametimeSeries.Points.AddRange(frametimes.Select((x, i) => new DataPoint(i, x)));
-            untilDisplayedTimesSeries.Points.AddRange(displaytimes.Select((x, i) => new DataPoint(i, x)));
+            for (int i = 0; i < frametimes.Count; i++)
+            {
+                if ((i & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
+                frametimeSeries.Points.Add(new DataPoint(i, frametimes[i]));
+            }
+            for (int i = 0; i < displaytimes.Count; i++)
+            {
+                if ((i & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
+                untilDisplayedTimesSeries.Points.Add(new DataPoint(i, displaytimes[i]));
+            }
 
             Application.Current.Dispatcher.Invoke(new Action(() =>
             {
+                if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
+
                 var tmp = new PlotModel
                 {
                     PlotMargins = new OxyThickness(40, 10, 40, 40),
@@ -503,8 +536,10 @@ namespace CapFrameX.ViewModel
             }));
         }
 
-        private void SetDisplayTimesHistogramChart(IList<double> displaytimes)
+        private void SetDisplayTimesHistogramChart(IList<double> displaytimes, int updateVersion,
+            CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
             var histogramValues = new ChartValues<double>();
             var bins = new List<double>();
 
@@ -517,6 +552,7 @@ namespace CapFrameX.ViewModel
 
                     for (int i = 0; i < discreteDistribution.Length; i++)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         var count = discreteDistribution[i].Count;
                         var avg = count > 0 ?
                                   discreteDistribution[i].Average() :
@@ -530,6 +566,8 @@ namespace CapFrameX.ViewModel
 
             Application.Current.Dispatcher.BeginInvoke(new Action(() =>
             {
+                if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
+
                 DisplayTimesHistogramCollection = new SeriesCollection
                 {
                     new LiveCharts.Wpf.ColumnSeries
@@ -547,8 +585,10 @@ namespace CapFrameX.ViewModel
             }));
         }
 
-        private void SetInputLagHistogramChart(IList<double> inputLagTimes)
+        private void SetInputLagHistogramChart(IList<double> inputLagTimes, int updateVersion,
+            CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
             var bins = new List<double>();
             var histogramValues = new ChartValues<double>();
 
@@ -561,6 +601,7 @@ namespace CapFrameX.ViewModel
 
                     for (int i = 0; i < discreteDistribution.Length; i++)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         var count = discreteDistribution[i].Count;
                         var avg = count > 0 ?
                                   discreteDistribution[i].Average() :
@@ -574,6 +615,8 @@ namespace CapFrameX.ViewModel
 
             Application.Current.Dispatcher.BeginInvoke(new Action(() =>
             {
+                if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
+
                 InputLagHistogramCollection = new SeriesCollection
                 {
                     new LiveCharts.Wpf.ColumnSeries
@@ -591,8 +634,10 @@ namespace CapFrameX.ViewModel
             }));
         }
 
-        private void SetInputLagStatisticChart(IList<double> inputLagTimes, IList<double> upperBoundInputLagTimes, IList<double> lowerBoundInputLagTimes)
+        private void SetInputLagStatisticChart(IList<double> inputLagTimes, IList<double> upperBoundInputLagTimes,
+            IList<double> lowerBoundInputLagTimes, int updateVersion, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
             double upperBound = 0;
             double expected = 0;
             double lowerBound = 0;
@@ -606,6 +651,8 @@ namespace CapFrameX.ViewModel
 
             Application.Current.Dispatcher.Invoke(new Action(() =>
             {
+                if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
+
                 IChartValues values = new ChartValues<double>
                 {
                     upperBound,
@@ -638,13 +685,17 @@ namespace CapFrameX.ViewModel
             }));
         }
 
-        private void SetDroppedFramesChart(List<bool> appMissed)
+        private void SetDroppedFramesChart(List<bool> appMissed, int updateVersion,
+            CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
             if (!appMissed.Any())
                 return;
 
             Application.Current.Dispatcher.BeginInvoke(new Action(() =>
             {
+                if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
+
                 DroppedFramesStatisticCollection = new SeriesCollection()
                 {
                     new LiveCharts.Wpf.PieSeries
@@ -685,8 +736,26 @@ namespace CapFrameX.ViewModel
                 .ToString() + "%";
         }
 
-        private void SetFrameInputLagChart(IList<double> frametimes, IList<double> upperBoundInputlagtimes, IList<double> lowerBoundInputlagtimes)
+        private bool IsCurrentChartUpdate(int updateVersion)
+            => Volatile.Read(ref _chartUpdateVersion) == updateVersion;
+
+        private static List<double> FilterFiniteValues(IList<double> values, CancellationToken cancellationToken)
         {
+            var result = new List<double>(values.Count);
+            for (int i = 0; i < values.Count; i++)
+            {
+                if ((i & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
+                if (!double.IsNaN(values[i])) result.Add(values[i]);
+            }
+            return result;
+        }
+
+        private void SetFrameInputLagChart(IList<double> frametimes, IList<double> upperBoundInputlagtimes,
+            IList<double> lowerBoundInputlagtimes, IList<bool> appMissed, int updateVersion,
+            CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
+
             if (frametimes.IsNullOrEmpty() ||
                 upperBoundInputlagtimes.IsNullOrEmpty() ||
                 lowerBoundInputlagtimes.IsNullOrEmpty() ||
@@ -694,23 +763,31 @@ namespace CapFrameX.ViewModel
                 lowerBoundInputlagtimes.All(t => double.IsNaN(t)))
             {
 
-                InputLagModel = new PlotModel
+                Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                 {
-                    PlotMargins = new OxyThickness(40, 10, 0, 40),
-                    PlotAreaBorderColor = _appConfiguration.UseDarkMode ? OxyColor.FromArgb(100, 204, 204, 204) : OxyColor.FromArgb(50, 30, 30, 30)
-                };
+                    if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
+                    InputLagModel = new PlotModel
+                    {
+                        PlotMargins = new OxyThickness(40, 10, 0, 40),
+                        PlotAreaBorderColor = _appConfiguration.UseDarkMode ? OxyColor.FromArgb(100, 204, 204, 204) : OxyColor.FromArgb(50, 30, 30, 30)
+                    };
 
-                InputLagModel.Legends.Add(new Legend()
-                {
-                    LegendPosition = LegendPosition.TopCenter,
-                    LegendOrientation = LegendOrientation.Horizontal
-                });
+                    InputLagModel.Legends.Add(new Legend()
+                    {
+                        LegendPosition = LegendPosition.TopCenter,
+                        LegendOrientation = LegendOrientation.Horizontal
+                    });
+                }));
 
                 return;
             }
 
-            var appMissed = _session.Runs.SelectMany(r => r.CaptureData.Dropped).ToList();
-            var filteredFrametimes = frametimes.Where((ft, i) => appMissed[i] != true).ToList();
+            var filteredFrametimes = new List<double>(frametimes.Count);
+            for (int i = 0; i < frametimes.Count; i++)
+            {
+                if ((i & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
+                if (!appMissed[i]) filteredFrametimes.Add(frametimes[i]);
+            }
 
             var yMin = Math.Min(filteredFrametimes.Min(), lowerBoundInputlagtimes.Min());
             var yMax = Math.Max(filteredFrametimes.Max(), upperBoundInputlagtimes.Max());
@@ -749,14 +826,28 @@ namespace CapFrameX.ViewModel
                 Fill = OxyColor.FromArgb(64, 225, 145, 145)
             };
 
-            frametimeSeries.Points.AddRange(filteredFrametimes.Select((x, i) => new DataPoint(i, x)));
-            upperBoundInputLagSeries.Points.AddRange(upperBoundInputlagtimes.Select((x, i) => new DataPoint(i, x)));
-            lowerBoundInputLagSeries.Points.AddRange(lowerBoundInputlagtimes.Select((x, i) => new DataPoint(i, x)));
-            areaSeries.Points.AddRange(lowerBoundInputlagtimes.Select((x, i) => new DataPoint(i, x)));
-            areaSeries.Points2.AddRange(upperBoundInputlagtimes.Select((x, i) => new DataPoint(i, x)));
+            for (int i = 0; i < filteredFrametimes.Count; i++)
+            {
+                if ((i & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
+                frametimeSeries.Points.Add(new DataPoint(i, filteredFrametimes[i]));
+            }
+            for (int i = 0; i < upperBoundInputlagtimes.Count; i++)
+            {
+                if ((i & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
+                upperBoundInputLagSeries.Points.Add(new DataPoint(i, upperBoundInputlagtimes[i]));
+                areaSeries.Points2.Add(new DataPoint(i, upperBoundInputlagtimes[i]));
+            }
+            for (int i = 0; i < lowerBoundInputlagtimes.Count; i++)
+            {
+                if ((i & 1023) == 0) cancellationToken.ThrowIfCancellationRequested();
+                lowerBoundInputLagSeries.Points.Add(new DataPoint(i, lowerBoundInputlagtimes[i]));
+                areaSeries.Points.Add(new DataPoint(i, lowerBoundInputlagtimes[i]));
+            }
 
             Application.Current.Dispatcher.Invoke(new Action(() =>
             {
+                if (cancellationToken.IsCancellationRequested || !IsCurrentChartUpdate(updateVersion)) return;
+
                 var tmp = new PlotModel
                 {
                     PlotMargins = new OxyThickness(40, 10, 40, 40),

--- a/source/CapFrameX/CapFrameX.csproj
+++ b/source/CapFrameX/CapFrameX.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>CapFrameX</RootNamespace>
     <AssemblyName>CapFrameX</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
## Summary

This change improves the responsiveness of record discovery, analysis, comparison, aggregation, and graph rendering while tightening the correctness of frametime-derived metrics and plotted data.

The branch starts at the exact `v1.8.6` commit (`383bc029`) and introduces no runtime or package dependencies.

## What changed

### Faster record discovery and loading

- Scan JSON metadata without deserializing the full frame and sensor payload merely to populate the record list.
- Parse only required CSV columns with a quote-aware, allocation-conscious reader.
- Reuse unchanged sessions through a bounded weak-reference/LRU cache; concurrent callers share one load operation.
- Cache record metadata in memory and in a bounded, versioned binary index built entirely with BCL APIs.
- Validate cached entries by normalized path, file length, and last-write time; invalidate on writes and recover safely from corrupt or stale indexes.
- Preserve process-list naming behavior across both memory and persistent metadata caches.

### More efficient and accurate statistics

- Batch FPS and frametime metric calculation so percentile inputs are sorted once instead of once per metric.
- Reuse exact sorted sequences while still detecting in-place sample mutation.
- Replace dense frametime-distribution work with a sparse, time-weighted accumulation algorithm.
- Correct deci-percentile removal at exact sample boundaries and retain constant sequences.
- Filter invalid timing samples consistently and preserve the original timestamps after outlier removal.
- Keep average FPS present-based while selecting display-change timing for low metrics only when every compared run supports it.
- Return the unchanged source for unsupported outlier modes instead of propagating `null`.

### More responsive and faithful visualization

- Perform record loading and expensive analysis work outside the WPF UI thread.
- Serialize selection loads and use cancellation/version guards so stale work cannot overwrite newer selections.
- Separate cancellation families for full analysis and threshold-only refreshes.
- Debounce rapid option changes and redraw immediately when the configured timing source changes.
- Decimate dense OxyPlot line rendering per screen column while preserving endpoints, minima, maxima, gaps, source tracker points, zoom behavior, and exports.
- Correct plot labels/axes, keep distribution plots anchored at zero, and clear plots when the session becomes invalid.
- Align GPU-active clipboard series by timestamp intersection and remove non-finite points instead of relying on matching array indices.
- Enable explicit WPF recycling virtualization for the main record and aggregation grids.

### Safer concurrent UI state

- Make comparison timing-source selection all-or-nothing across records and expose the selected source in the UI.
- Make aggregation add/update operations transactional, with rollback and cleanup on cancellation or failure.
- Observe and log background sensor-report faults.
- Separate online metric buffers to remove a cross-lock race.

### Regression coverage and developer workflow

- Add focused tests for session reuse/invalidation, concurrent loads, persistent-index recovery, process-list renames, incomplete JSON, quoted CSV, distribution math, timing-cache mutation, outlier handling, display-source fallback, timestamp alignment, and plot decimation.
- Add `Build-And-Run.ps1` for a one-command x64 Release restore/build/launch workflow. It discovers a compatible Visual Studio toolchain and may request elevation to install missing v143/MFC/C++/CLI components.

## Positive impact

- Record-list refreshes avoid loading full capture object graphs, reducing both startup I/O and allocation pressure.
- Reopening unchanged captures is effectively a cache lookup rather than a repeat parse.
- Rapid selection and settings changes remain responsive and cannot publish stale calculations.
- Large graphs draw far fewer screen points without hiding short spikes, dips, gaps, or endpoints.
- Frametime distributions no longer scale with `sample count x bin count`, avoiding severe stalls on long captures or isolated large hitches.
- Average, 1%, 0.2%, 0.1%, percentile, integral-low, threshold, and distribution results share validated timing inputs and explicit timing-source rules.

Indicative local synthetic benchmarks during development (hardware/data dependent):

- Sixteen metrics over 1,000,000 samples: about **64 ms batched** versus **279 ms** through repeated per-metric calls (~4.4x faster); an unchanged cached repeat was about **1.4 ms**.
- A 200,000-sample time-weighted distribution containing a 10-second hitch: about **13 ms** versus **46 s** for the previous dense traversal (~3,500x faster for that stress case).

## Compatibility and behavior notes

- No SQLite, database engine, or new NuGet dependency is introduced.
- The persistent metadata index is disposable acceleration data: stale/corrupt entries fall back to source parsing and are rebuilt.
- Correct quote-aware CSV selection can intentionally produce a different hash from the old parser when quoted fields contain commas, because the selected/analyzed rows are now the rows represented by the CSV.
- A final deferred metadata-index update can be lost on forced process termination; capture data remains safe and the index is rebuilt later.

## Validation

- `x64 Release` application build: **passed**, 0 errors.
- `x64 Release` test assembly build: **passed**, 0 errors.
- Full MSTest run: **297 total, 292 passed, 5 skipped, 0 failed**.
- The five skips require a live PresentMon-compatible capture target/hardware environment.
- `git diff --check`: **passed**.

## Run locally

```powershell
powershell -NoProfile -ExecutionPolicy Bypass -File .\Build-And-Run.ps1
```
