### PR TITLE
Improve record parsing and in-memory loading

### DIFF
--- a/source/CapFrameX.Data/FileRecordInfo.cs
+++ b/source/CapFrameX.Data/FileRecordInfo.cs
@@ -58,48 +58,66 @@ namespace CapFrameX.Data
 		public string HAGS { get; private set; }
 		public string PresentationMode { get; private set; }
 		public string Resolution { get; private set; }
+		internal bool UsesProcessListGameName { get; set; }
 
 		private FileRecordInfo(FileInfo fileInfo, ISession session)
+			: this(fileInfo, session?.Info, session?.Hash, session?.Runs?.Count ?? 0,
+				session?.Runs?.LastOrDefault()?.CaptureData?.TimeInSeconds?.LastOrDefault() ?? 0)
 		{
-			var creationDateTime = session.Info.CreationDate.ToLocalTime();
+		}
+
+		private FileRecordInfo(FileInfo fileInfo, ISessionInfo sessionInfo, string hash,
+			int runCount, double recordTime)
+		{
+			if (fileInfo == null || sessionInfo == null)
+			{
+				throw new ArgumentException("Record metadata is incomplete.");
+			}
+
+			var creationDateTime = sessionInfo.CreationDate.ToLocalTime();
 			FileInfo = fileInfo;
 			FullPath = fileInfo.FullName;
-			Id = session.Info.Id.ToString();
+			Id = sessionInfo.Id.ToString();
 			CreationDate = creationDateTime.ToString("yyyy-MM-dd");
 			CreationTime = creationDateTime.ToString("HH:mm:ss");
-			ProcessName = session.Info.ProcessName;
-			GameName = session.Info.GameName;
-			ProcessorName = session.Info.Processor;
-			GraphicCardName = session.Info.GPU;
-			SystemRamInfo = session.Info.SystemRam;
-			MotherboardName = session.Info.Motherboard;
-			OsVersion = session.Info.OS;
-			GPUMemoryClock = session.Info.GpuMemoryClock;
-			GPUCoreClock = session.Info.GpuCoreClock;
-			DriverPackage = session.Info.DriverPackage;
-			BaseDriverVersion = session.Info.BaseDriverVersion;
-			GPUDriverVersion = session.Info.GPUDriverVersion;
-			Comment = session.Info.Comment;
-			ProcessName = session.Info.ProcessName;
-			IsAggregated = Convert.ToString(session.Runs.Count() > 1);
+			ProcessName = sessionInfo.ProcessName;
+			GameName = sessionInfo.GameName;
+			ProcessorName = sessionInfo.Processor;
+			GraphicCardName = sessionInfo.GPU;
+			SystemRamInfo = sessionInfo.SystemRam;
+			MotherboardName = sessionInfo.Motherboard;
+			OsVersion = sessionInfo.OS;
+			GPUMemoryClock = sessionInfo.GpuMemoryClock;
+			GPUCoreClock = sessionInfo.GpuCoreClock;
+			DriverPackage = sessionInfo.DriverPackage;
+			BaseDriverVersion = sessionInfo.BaseDriverVersion;
+			GPUDriverVersion = sessionInfo.GPUDriverVersion;
+			Comment = sessionInfo.Comment;
+			IsAggregated = Convert.ToString(runCount > 1);
 			IsValid = true;
-			Hash = session.Hash;
-			ApiInfo = session.Info.ApiInfo;
-			ResizableBar = session.Info.ResizableBar;
-			WinGameMode = session.Info.WinGameMode;
-			HAGS = session.Info.HAGS;
-			PresentationMode = session.Info.PresentationMode;
-			Resolution = session.Info.ResolutionInfo;
+			Hash = hash;
+			RecordTime = recordTime;
+			ApiInfo = sessionInfo.ApiInfo;
+			ResizableBar = sessionInfo.ResizableBar;
+			WinGameMode = sessionInfo.WinGameMode;
+			HAGS = sessionInfo.HAGS;
+			PresentationMode = sessionInfo.PresentationMode;
+			Resolution = sessionInfo.ResolutionInfo;
 		}
 
 		private FileRecordInfo(FileInfo fileInfo, string hash)
+			: this(fileInfo, hash, null)
+		{
+		}
+
+		private FileRecordInfo(FileInfo fileInfo, string hash, string[] lines)
 		{
 			if (fileInfo != null && File.Exists(fileInfo.FullName))
 			{
 				FileInfo = fileInfo;
 				FullPath = fileInfo.FullName;
 				Hash = hash;
-				_lines = File.ReadAllLines(fileInfo.FullName);
+				_lines = lines ?? File.ReadAllLines(fileInfo.FullName);
 
 				if (_lines != null && _lines.Any())
 				{
@@ -373,6 +391,26 @@ namespace CapFrameX.Data
 			return recordInfo;
 		}
 
+		internal static IFileRecordInfo Create(FileInfo fileInfo, string hash, string[] lines)
+		{
+			FileRecordInfo recordInfo = null;
+
+			try
+			{
+				recordInfo = new FileRecordInfo(fileInfo, hash, lines);
+			}
+			catch (ArgumentException)
+			{
+				// Log
+			}
+			catch (Exception)
+			{
+				// Log
+			}
+
+			return recordInfo;
+		}
+
 		public static IFileRecordInfo Create(FileInfo fileInfo, ISession session)
 		{
 			FileRecordInfo recordInfo = null;
@@ -391,6 +429,19 @@ namespace CapFrameX.Data
 			}
 
 			return recordInfo;
+		}
+
+		internal static IFileRecordInfo Create(FileInfo fileInfo, ISessionInfo sessionInfo,
+			string hash, int runCount, double recordTime)
+		{
+			try
+			{
+				return new FileRecordInfo(fileInfo, sessionInfo, hash, runCount, recordTime);
+			}
+			catch (Exception)
+			{
+				return null;
+			}
 		}
 
 		public static bool IsMangoHudFile(string line)

--- a/source/CapFrameX.Data/RecordManager.cs
+++ b/source/CapFrameX.Data/RecordManager.cs
@@ -1131,6 +1131,7 @@ namespace CapFrameX.Data
                     }
 
                     _logger.LogInformation("{FilePath} successfully written", filePath);
+                    InvalidateSessionCache(filePath);
                 }
                 catch (Exception ex)
                 {

--- a/source/CapFrameX.Data/RecordManager.cs
+++ b/source/CapFrameX.Data/RecordManager.cs
@@ -24,7 +24,9 @@ using System.Reactive.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CapFrameX.Data
@@ -41,6 +43,26 @@ namespace CapFrameX.Data
     public class RecordManager : IRecordManager
     {
         private const string IGNOREFLAGMARKER = "//Ignore=true";
+        private const int SESSION_CACHE_CAPACITY = 16;
+        private const int RECORD_INFO_CACHE_CAPACITY = 4096;
+        private sealed class SessionCacheEntry
+        {
+            public long Length;
+            public long LastWriteTimeUtcTicks;
+            // Session models are mutable. A weak reference avoids extending their lifetime and
+            // lets memory pressure discard large captures while active views can still reuse them.
+            public WeakReference<ISession> Session;
+            public Lazy<ISession> LoadingSession;
+            public long LastAccess;
+        }
+
+        private sealed class RecordInfoCacheEntry
+        {
+            public long Length;
+            public long LastWriteTimeUtcTicks;
+            public IFileRecordInfo RecordInfo;
+            public long LastAccess;
+        }
 
         private readonly TimeSpan _fileAccessIntervalTimespan = TimeSpan.FromMilliseconds(200);
         private readonly int _fileAccessIntervalRetryLimit = 50;
@@ -54,6 +76,13 @@ namespace CapFrameX.Data
         private readonly IRTSSService _rTSSService;
         private readonly IEventAggregator _eventAggregator;
         private readonly ICaptureService _captureService;
+        private readonly object _sessionCacheSync = new object();
+        private readonly Dictionary<string, SessionCacheEntry> _sessionCache =
+            new Dictionary<string, SessionCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, RecordInfoCacheEntry> _recordInfoCache =
+            new Dictionary<string, RecordInfoCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        private long _sessionCacheAccessSequence;
+        private long _recordInfoCacheAccessSequence;
         private PubSubEvent<ViewMessages.UpdateSystemInfo> _updateSystemInfoEvent;
 
         [DllImport("user32.dll", SetLastError = true)]
@@ -137,6 +166,7 @@ namespace CapFrameX.Data
                         lines[commentNameHeaderIndex] = $"{FileRecordInfo.HEADER_MARKER}Comment{FileRecordInfo.INFO_SEPERATOR}{customComment}";
 
                         File.WriteAllLines(recordInfo.FullPath, lines);
+                        InvalidateSessionCache(recordInfo.FullPath);
                     }
                     else
                     {
@@ -163,6 +193,7 @@ namespace CapFrameX.Data
 
                         recordInfo.HasInfoHeader = true;
                         File.WriteAllLines(recordInfo.FullPath, headerLines.Concat(lines));
+                        InvalidateSessionCache(recordInfo.FullPath);
                     }
                 }
             }
@@ -238,15 +269,110 @@ namespace CapFrameX.Data
             {
                 return null;
             }
-            var fileInfo = new FileInfo(path);
-
-            if (!fileInfo.Exists || fileInfo.Length == 0)
-            {
-                return null;
-            }
-
             try
             {
+                var normalizedPath = Path.GetFullPath(path);
+                var fileInfo = new FileInfo(normalizedPath);
+
+                if (!fileInfo.Exists || fileInfo.Length == 0)
+                {
+                    InvalidateSessionCache(normalizedPath);
+                    return null;
+                }
+
+                if (fileInfo.Extension != ".json" && fileInfo.Extension != ".csv")
+                {
+                    return null;
+                }
+
+                long length = fileInfo.Length;
+                long lastWriteTimeUtcTicks = fileInfo.LastWriteTimeUtc.Ticks;
+                SessionCacheEntry cacheEntry;
+                Lazy<ISession> loadingSession;
+
+                lock (_sessionCacheSync)
+                {
+                    if (_sessionCache.TryGetValue(normalizedPath, out cacheEntry)
+                        && cacheEntry.Length == length
+                        && cacheEntry.LastWriteTimeUtcTicks == lastWriteTimeUtcTicks)
+                    {
+                        cacheEntry.LastAccess = ++_sessionCacheAccessSequence;
+                        if (cacheEntry.Session != null
+                            && cacheEntry.Session.TryGetTarget(out var cachedSession))
+                        {
+                            return cachedSession;
+                        }
+
+                        if (cacheEntry.LoadingSession == null)
+                        {
+                            cacheEntry.LoadingSession = CreateSessionLoader(normalizedPath);
+                        }
+                    }
+                    else
+                    {
+                        cacheEntry = new SessionCacheEntry
+                        {
+                            Length = length,
+                            LastWriteTimeUtcTicks = lastWriteTimeUtcTicks,
+                            LastAccess = ++_sessionCacheAccessSequence,
+                            LoadingSession = CreateSessionLoader(normalizedPath)
+                        };
+                        _sessionCache[normalizedPath] = cacheEntry;
+                        TrimSessionCacheLocked(normalizedPath);
+                    }
+
+                    loadingSession = cacheEntry.LoadingSession;
+                }
+
+                ISession loadedSession;
+                try
+                {
+                    // Lazy<T> makes concurrent requests for the same file share one parse.
+                    loadedSession = loadingSession.Value;
+                }
+                catch
+                {
+                    RemoveSessionCacheEntry(normalizedPath, cacheEntry);
+                    throw;
+                }
+
+                fileInfo.Refresh();
+                bool fileUnchanged = fileInfo.Exists
+                    && fileInfo.Length == length
+                    && fileInfo.LastWriteTimeUtc.Ticks == lastWriteTimeUtcTicks;
+
+                lock (_sessionCacheSync)
+                {
+                    if (_sessionCache.TryGetValue(normalizedPath, out var currentEntry)
+                        && ReferenceEquals(currentEntry, cacheEntry))
+                    {
+                        currentEntry.LoadingSession = null;
+                        if (loadedSession != null && fileUnchanged)
+                        {
+                            currentEntry.Session = new WeakReference<ISession>(loadedSession);
+                            currentEntry.LastAccess = ++_sessionCacheAccessSequence;
+                        }
+                        else
+                        {
+                            _sessionCache.Remove(normalizedPath);
+                        }
+                    }
+                }
+
+                return loadedSession;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error while loading {path}", path);
+                return null;
+            }
+        }
+
+        private Lazy<ISession> CreateSessionLoader(string normalizedPath)
+        {
+            return new Lazy<ISession>(() =>
+            {
+                var fileInfo = new FileInfo(normalizedPath);
                 switch (fileInfo.Extension)
                 {
                     case ".json":
@@ -256,11 +382,58 @@ namespace CapFrameX.Data
                     default:
                         return null;
                 }
+            }, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        private void InvalidateSessionCache(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            try
+            {
+                string normalizedPath = Path.GetFullPath(path);
+                lock (_sessionCacheSync)
+                {
+                    _sessionCache.Remove(normalizedPath);
+                    _recordInfoCache.Remove(normalizedPath);
+                }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error while loading {path}", path);
-                return null;
+                _logger.LogDebug(ex, "Unable to invalidate cached session for {path}", path);
+            }
+        }
+
+        private void RemoveSessionCacheEntry(string normalizedPath, SessionCacheEntry expectedEntry)
+        {
+            lock (_sessionCacheSync)
+            {
+                if (_sessionCache.TryGetValue(normalizedPath, out var currentEntry)
+                    && ReferenceEquals(currentEntry, expectedEntry))
+                {
+                    _sessionCache.Remove(normalizedPath);
+                }
+            }
+        }
+
+        private void TrimSessionCacheLocked(string preservedPath)
+        {
+            while (_sessionCache.Count > SESSION_CACHE_CAPACITY)
+            {
+                var candidate = _sessionCache
+                    .Where(pair => !string.Equals(pair.Key, preservedPath, StringComparison.OrdinalIgnoreCase))
+                    .OrderBy(pair => pair.Value.LastAccess)
+                    .FirstOrDefault();
+
+                if (candidate.Key == null)
+                {
+                    return;
+                }
+
+                _sessionCache.Remove(candidate.Key);
             }
         }
 
@@ -301,6 +474,13 @@ namespace CapFrameX.Data
 
         private ISession LoadSessionFromCSV(FileInfo csvFile)
         {
+            return LoadSessionFromCSV(csvFile, out _);
+        }
+
+        private ISession LoadSessionFromCSV(FileInfo csvFile, out IFileRecordInfo recordedFileInfo)
+        {
+            recordedFileInfo = null;
+
             // Exception: ignore Nv FrameView summary file
             if (csvFile.Name == "FrameView_Summary.csv")
                 return null;
@@ -309,63 +489,60 @@ namespace CapFrameX.Data
             if (csvFile.Name.Contains("-stats.csv"))
                 return null;
 
-            using (var reader = new StreamReader(csvFile.FullName))
+            var lines = File.ReadAllLines(csvFile.FullName);
+            if (lines.First().Equals(IGNOREFLAGMARKER))
             {
-                var lines = File.ReadAllLines(csvFile.FullName);
-                if (lines.First().Equals(IGNOREFLAGMARKER))
-                {
-                    throw new HasIgnoreFlagException();
-                }
-
-                IEnumerable<string> skippedLines = null;
-
-                // MangoHud capture file
-                if (lines.First().Contains("cpuscheduler") && lines.First().Contains("kernel"))
-                {
-                    skippedLines = lines.Skip(2);
-
-                }
-                // Standard CSV with header
-                else
-                {
-                    skippedLines = lines.SkipWhile(line => line.Contains(FileRecordInfo.HEADER_MARKER));
-
-                    if (FileRecordInfo.IsMangoHudFile(skippedLines.First()))
-                    {
-                        skippedLines = skippedLines.Skip(2);
-                    }
-                }
-
-                var sessionRun = ConvertPresentDataLinesToSessionRun(skippedLines);
-                var recordedFileInfo = FileRecordInfo.Create(csvFile, sessionRun.Hash);
-                var systemInfos = GetSystemInfos(recordedFileInfo);
-
-                return new Session.Classes.Session()
-                {
-                    Hash = string.Join(",", new string[] { sessionRun.Hash }).GetSha1(),
-                    Runs = new List<ISessionRun>() { sessionRun },
-                    Info = new SessionInfo()
-                    {
-                        ProcessName = recordedFileInfo.ProcessName,
-                        Processor = recordedFileInfo.ProcessorName,
-                        GPU = recordedFileInfo.GraphicCardName,
-                        BaseDriverVersion = recordedFileInfo.BaseDriverVersion,
-                        GameName = recordedFileInfo.GameName,
-                        Comment = recordedFileInfo.Comment,
-                        Id = Guid.TryParse(recordedFileInfo.Id, out var guidId) ? guidId : Guid.NewGuid(),
-                        OS = recordedFileInfo.OsVersion,
-                        GpuCoreClock = recordedFileInfo.GPUCoreClock,
-                        GPUCount = recordedFileInfo.NumberGPUs,
-                        SystemRam = recordedFileInfo.SystemRamInfo,
-                        Motherboard = recordedFileInfo.MotherboardName,
-                        DriverPackage = recordedFileInfo.DriverPackage,
-                        GpuMemoryClock = recordedFileInfo.GPUMemoryClock,
-                        CreationDate = DateTime.TryParse(recordedFileInfo.CreationDate + "T" + recordedFileInfo.CreationTime, out var creationDate) ? creationDate : new DateTime(),
-                        AppVersion = new Version(),
-                        ApiInfo = recordedFileInfo.ApiInfo
-                    }
-                };
+                throw new HasIgnoreFlagException();
             }
+
+            IEnumerable<string> skippedLines = null;
+
+            // MangoHud capture file
+            if (lines.First().Contains("cpuscheduler") && lines.First().Contains("kernel"))
+            {
+                skippedLines = lines.Skip(2);
+
+            }
+            // Standard CSV with header
+            else
+            {
+                skippedLines = lines.SkipWhile(line => line.Contains(FileRecordInfo.HEADER_MARKER));
+
+                if (FileRecordInfo.IsMangoHudFile(skippedLines.First()))
+                {
+                    skippedLines = skippedLines.Skip(2);
+                }
+            }
+
+            var sessionRun = ConvertPresentDataLinesToSessionRun(skippedLines);
+            var sessionHash = sessionRun.Hash.GetSha1();
+            recordedFileInfo = FileRecordInfo.Create(csvFile, sessionHash, lines);
+
+            return new Session.Classes.Session()
+            {
+                Hash = sessionHash,
+                Runs = new List<ISessionRun>() { sessionRun },
+                Info = new SessionInfo()
+                {
+                    ProcessName = recordedFileInfo.ProcessName,
+                    Processor = recordedFileInfo.ProcessorName,
+                    GPU = recordedFileInfo.GraphicCardName,
+                    BaseDriverVersion = recordedFileInfo.BaseDriverVersion,
+                    GameName = recordedFileInfo.GameName,
+                    Comment = recordedFileInfo.Comment,
+                    Id = Guid.TryParse(recordedFileInfo.Id, out var guidId) ? guidId : Guid.NewGuid(),
+                    OS = recordedFileInfo.OsVersion,
+                    GpuCoreClock = recordedFileInfo.GPUCoreClock,
+                    GPUCount = recordedFileInfo.NumberGPUs,
+                    SystemRam = recordedFileInfo.SystemRamInfo,
+                    Motherboard = recordedFileInfo.MotherboardName,
+                    DriverPackage = recordedFileInfo.DriverPackage,
+                    GpuMemoryClock = recordedFileInfo.GPUMemoryClock,
+                    CreationDate = DateTime.TryParse(recordedFileInfo.CreationDate + "T" + recordedFileInfo.CreationTime, out var creationDate) ? creationDate : new DateTime(),
+                    AppVersion = new Version(),
+                    ApiInfo = recordedFileInfo.ApiInfo
+                }
+            };
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -373,32 +550,38 @@ namespace CapFrameX.Data
         {
             if (index < array.Length && index > -1)
             {
-                return array[index];
+                return array[index] ?? string.Empty;
             }
             return string.Empty;
         }
 
         public async Task<IFileRecordInfo> GetFileRecordInfo(FileInfo fileInfo)
         {
-            return await Observable.Timer(_fileAccessIntervalTimespan)
+            fileInfo.Refresh();
+            if (TryGetCachedRecordInfo(fileInfo, out var cachedRecordInfo))
+            {
+                return cachedRecordInfo;
+            }
+            long expectedLength = fileInfo.Length;
+            long expectedLastWriteTimeUtcTicks = fileInfo.LastWriteTimeUtc.Ticks;
+
+            var recordInfo = await Observable.Timer(_fileAccessIntervalTimespan)
                 .SelectMany(_ =>
                 {
                     switch (fileInfo.Extension)
                     {
                         case ".csv":
-                            var sessionFromCSV = LoadSessionFromCSV(fileInfo);
+                            var sessionFromCSV = LoadSessionFromCSV(fileInfo, out var recordInfoFromCSV);
 
                             if (sessionFromCSV == null)
                                 return Observable.Empty<IFileRecordInfo>();
 
-                            return Observable.Return(FileRecordInfo.Create(fileInfo, sessionFromCSV.Hash));
+                            return Observable.Return(recordInfoFromCSV);
                         case ".json":
-                            var sessionFromJSON = LoadSessionFromJSON(fileInfo);
-
-                            if (sessionFromJSON == null)
-                                return Observable.Empty<IFileRecordInfo>();
-
-                            return Observable.Return(FileRecordInfo.Create(fileInfo, sessionFromJSON));
+                            var recordInfoFromJSON = LoadRecordInfoFromJSON(fileInfo);
+                            return recordInfoFromJSON == null
+                                ? Observable.Empty<IFileRecordInfo>()
+                                : Observable.Return(recordInfoFromJSON);
                         default:
                             return Observable.Empty<IFileRecordInfo>();
                     }
@@ -419,23 +602,230 @@ namespace CapFrameX.Data
                     }
                 })
                 .Retry(_fileAccessIntervalRetryLimit)
+                .DefaultIfEmpty()
                 .Do(fileRecordInfo =>
                 {
-                    if (fileRecordInfo is IFileRecordInfo)
+                    if (fileRecordInfo != null)
                     {
-                        if (fileRecordInfo.ProcessName == fileRecordInfo.GameName)
-                        {
+                        bool usesProcessListName = fileRecordInfo.ProcessName == fileRecordInfo.GameName
+                            || fileRecordInfo.GameName.IsNullOrEmpty();
+                        if (fileRecordInfo is FileRecordInfo concreteRecordInfo)
+                            concreteRecordInfo.UsesProcessListGameName = usesProcessListName;
+                        if (usesProcessListName)
                             fileRecordInfo.GameName = GetGameNameFromProcessList(fileRecordInfo.ProcessName);
-                        }
-                        else
-                        {
-                            if (fileRecordInfo.GameName.IsNullOrEmpty())
-                            {
-                                fileRecordInfo.GameName = GetGameNameFromProcessList(fileRecordInfo.ProcessName);
-                            }
-                        }
                     }
                 });
+
+            if (recordInfo != null)
+            {
+                StoreRecordInfo(fileInfo, recordInfo, expectedLength, expectedLastWriteTimeUtcTicks);
+            }
+
+            return recordInfo;
+        }
+
+        private IFileRecordInfo LoadRecordInfoFromJSON(FileInfo fileInfo)
+        {
+            using (var stream = new StreamReader(fileInfo.FullName))
+            using (var jsonReader = new JsonTextReader(stream))
+            {
+                var serializer = new JsonSerializer();
+                string hash = null;
+                ISessionInfo sessionInfo = null;
+                int runCount = 0;
+                double recordTime = 0;
+
+                while (jsonReader.Read())
+                {
+                    if (jsonReader.TokenType != JsonToken.PropertyName)
+                    {
+                        continue;
+                    }
+
+                    string propertyName = Convert.ToString(jsonReader.Value, CultureInfo.InvariantCulture);
+                    if (!jsonReader.Read())
+                    {
+                        break;
+                    }
+
+                    if (string.Equals(propertyName, "Hash", StringComparison.OrdinalIgnoreCase))
+                    {
+                        hash = Convert.ToString(jsonReader.Value, CultureInfo.InvariantCulture);
+                    }
+                    else if (string.Equals(propertyName, "Info", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sessionInfo = serializer.Deserialize<SessionInfo>(jsonReader);
+                    }
+                    else if (string.Equals(propertyName, "Runs", StringComparison.OrdinalIgnoreCase)
+                        && jsonReader.TokenType == JsonToken.StartArray)
+                    {
+                        ReadRunMetadata(jsonReader, ref runCount, ref recordTime);
+                    }
+                    else
+                    {
+                        jsonReader.Skip();
+                    }
+                }
+
+                return sessionInfo == null || runCount == 0
+                    ? null
+                    : FileRecordInfo.Create(fileInfo, sessionInfo, hash, runCount, recordTime);
+            }
+        }
+
+        private static void ReadRunMetadata(JsonReader reader, ref int runCount, ref double recordTime)
+        {
+            int arrayDepth = reader.Depth;
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonToken.EndArray && reader.Depth == arrayDepth)
+                {
+                    return;
+                }
+
+                if (reader.TokenType == JsonToken.StartObject && reader.Depth == arrayDepth + 1)
+                {
+                    runCount++;
+                    ReadSingleRunMetadata(reader, ref recordTime);
+                }
+            }
+        }
+
+        private static void ReadSingleRunMetadata(JsonReader reader, ref double recordTime)
+        {
+            int objectDepth = reader.Depth;
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonToken.EndObject && reader.Depth == objectDepth)
+                {
+                    return;
+                }
+
+                if (reader.TokenType != JsonToken.PropertyName)
+                {
+                    continue;
+                }
+
+                string propertyName = Convert.ToString(reader.Value, CultureInfo.InvariantCulture);
+                if (!reader.Read())
+                {
+                    return;
+                }
+
+                if (string.Equals(propertyName, "CaptureData", StringComparison.OrdinalIgnoreCase)
+                    && reader.TokenType == JsonToken.StartObject)
+                {
+                    ReadCaptureRecordTime(reader, ref recordTime);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+        }
+
+        private static void ReadCaptureRecordTime(JsonReader reader, ref double recordTime)
+        {
+            int objectDepth = reader.Depth;
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonToken.EndObject && reader.Depth == objectDepth)
+                {
+                    return;
+                }
+
+                if (reader.TokenType != JsonToken.PropertyName)
+                {
+                    continue;
+                }
+
+                string propertyName = Convert.ToString(reader.Value, CultureInfo.InvariantCulture);
+                if (!reader.Read())
+                {
+                    return;
+                }
+
+                if (string.Equals(propertyName, "TimeInSeconds", StringComparison.OrdinalIgnoreCase)
+                    && reader.TokenType == JsonToken.StartArray)
+                {
+                    int arrayDepth = reader.Depth;
+                    while (reader.Read())
+                    {
+                        if (reader.TokenType == JsonToken.EndArray && reader.Depth == arrayDepth)
+                        {
+                            break;
+                        }
+
+                        if (reader.TokenType == JsonToken.Float || reader.TokenType == JsonToken.Integer)
+                        {
+                            recordTime = Convert.ToDouble(reader.Value, CultureInfo.InvariantCulture);
+                        }
+                    }
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+        }
+
+        private bool TryGetCachedRecordInfo(FileInfo fileInfo, out IFileRecordInfo recordInfo)
+        {
+            recordInfo = null;
+            if (!fileInfo.Exists || fileInfo.Length == 0)
+            {
+                return false;
+            }
+
+            string path = Path.GetFullPath(fileInfo.FullName);
+            lock (_sessionCacheSync)
+            {
+                if (_recordInfoCache.TryGetValue(path, out var entry)
+                    && entry.Length == fileInfo.Length
+                    && entry.LastWriteTimeUtcTicks == fileInfo.LastWriteTimeUtc.Ticks)
+                {
+                    entry.LastAccess = ++_recordInfoCacheAccessSequence;
+                    recordInfo = entry.RecordInfo;
+                    if (recordInfo is FileRecordInfo concreteRecordInfo
+                        && concreteRecordInfo.UsesProcessListGameName)
+                    {
+                        recordInfo.GameName = GetGameNameFromProcessList(recordInfo.ProcessName);
+                    }
+                    return recordInfo != null;
+                }
+
+                _recordInfoCache.Remove(path);
+            }
+            return false;
+        }
+
+        private void StoreRecordInfo(FileInfo fileInfo, IFileRecordInfo recordInfo,
+            long expectedLength, long expectedLastWriteTimeUtcTicks)
+        {
+            fileInfo.Refresh();
+            if (!fileInfo.Exists || fileInfo.Length != expectedLength
+                || fileInfo.LastWriteTimeUtc.Ticks != expectedLastWriteTimeUtcTicks)
+            {
+                return;
+            }
+
+            string path = Path.GetFullPath(fileInfo.FullName);
+            lock (_sessionCacheSync)
+            {
+                _recordInfoCache[path] = new RecordInfoCacheEntry
+                {
+                    Length = fileInfo.Length,
+                    LastWriteTimeUtcTicks = fileInfo.LastWriteTimeUtc.Ticks,
+                    RecordInfo = recordInfo,
+                    LastAccess = ++_recordInfoCacheAccessSequence
+                };
+
+                while (_recordInfoCache.Count > RECORD_INFO_CACHE_CAPACITY)
+                {
+                    var oldest = _recordInfoCache.OrderBy(pair => pair.Value.LastAccess).First();
+                    _recordInfoCache.Remove(oldest.Key);
+                }
+            }
         }
 
         public async Task SavePresentmonRawToFile(IEnumerable<string> lines, string process, string recordDirectory = null)
@@ -785,7 +1175,7 @@ namespace CapFrameX.Data
             }
 
             var processNameExtStripped = processName.StripExeExtension();
-            return _processList.FindProcessByName(processName)?.DisplayName ?? processNameExtStripped;
+            return _processList?.FindProcessByName(processName)?.DisplayName ?? processNameExtStripped;
         }
 
         private string GetGameNameFromFileDescription(string processName)
@@ -882,11 +1272,11 @@ namespace CapFrameX.Data
                 }
 
                 // Filter lines by dominant process and SwapChainAddress
-                presentLines = FilterByDominantSwapChain(presentLines, headerLine);
+                var dataLines = FilterByDominantSwapChain(presentLines, headerLine);
 
                 var sessionRun = new SessionRun()
                 {
-                    Hash = string.Join(",", presentLines).GetSha1(),
+                    Hash = GetPresentLinesSha1(dataLines),
                     PresentMonRuntime = "unknown"
                 };
 
@@ -898,7 +1288,7 @@ namespace CapFrameX.Data
 
                 string frameStartUnit = "s";
                 var metrics = Array.ConvertAll(headerLine.Split(','), p => p.Trim());
-                for (int i = 0; i < metrics.Count(); i++)
+                for (int i = 0; i < metrics.Length; i++)
                 {
                     if (string.Compare(metrics[i], "AppRenderStart") == 0 || string.Compare(metrics[i], "TimeInSeconds") == 0
                          || string.Compare(metrics[i], "TimeInMs") == 0)
@@ -985,7 +1375,7 @@ namespace CapFrameX.Data
                     }
                 }
 
-                var presentLineCount = presentLines.Count();
+                var presentLineCount = dataLines.Count;
                 var captureData = new SessionCaptureData(presentLineCount)
                 {
                     AnimationError = Enumerable.Repeat(double.NaN, presentLineCount).ToArray()
@@ -997,37 +1387,25 @@ namespace CapFrameX.Data
                     captureData.PcLatency = new double[presentLineCount];
                 }
 
-                var dataLines = presentLines.ToArray();
-
                 var presentModeMapping = Enum.GetValues(typeof(EPresentMode)).Cast<EPresentMode>()
                     .ToDictionary(e => e.GetDescription(), e => (int)e);
-                for (int lineIndex = 0; lineIndex < dataLines.Count(); lineIndex++)
+                var requiredColumns = new bool[metrics.Length];
+                MarkRequiredColumns(requiredColumns,
+                    indexFrameStart, indexFrameTimes, indexUntilDisplayedTimes, indexAppMissed,
+                    indexPresentMode, indexMsInPresentAPI, indexDisplayTimes, indexQPCTimes,
+                    indexRuntime, indexAllowsTearing, indexSyncInterval, indexFrameType,
+                    indexPcLatency, indexMsAnimationError, indexmsGPUActive, indexmsCPUActive,
+                    indexCPUStartQPCTime, indexCPUStartQPCTimeInMs);
+                var values = new string[metrics.Length];
+
+                for (int lineIndex = 0; lineIndex < dataLines.Count; lineIndex++)
                 {
                     string line = dataLines[lineIndex];
-                    if (!line.Any())
+                    if (line.Length == 0)
                     {
                         continue;
                     }
-                    var lineCharList = new List<char>();
-                    string[] values = Array.Empty<string>();
-
-                    if (lineIndex == 0)
-                    {
-                        int isInner = -1;
-                        for (int i = 0; i < line.Length; i++)
-                        {
-                            if (line[i] == '"')
-                                isInner *= -1;
-
-                            if (!(line[i] == ',' && isInner == 1))
-                                lineCharList.Add(line[i]);
-
-                        }
-
-                        line = new string(lineCharList.ToArray());
-                    }
-
-                    values = line.Split(',');
+                    ParseCsvFields(line, values, requiredColumns);
                     double frameStart = 0;
 
                     if (lineIndex == 0)
@@ -1220,10 +1598,10 @@ namespace CapFrameX.Data
         /// Filters present data lines to include only the dominant process and its dominant SwapChainAddress.
         /// This handles scenarios where multiple processes or multiple swap chains per process are present.
         /// </summary>
-        private IEnumerable<string> FilterByDominantSwapChain(IEnumerable<string> presentLines, string headerLine)
+        private List<string> FilterByDominantSwapChain(IEnumerable<string> presentLines, string headerLine)
         {
             var linesList = presentLines.ToList();
-            if (!linesList.Any())
+            if (linesList.Count == 0)
                 return linesList;
 
             // Find SwapChainAddress index from header
@@ -1243,57 +1621,79 @@ namespace CapFrameX.Data
             if (swapChainIndex < 0 || processNameIndex < 0)
                 return linesList;
 
-            // Parse all lines to extract (ProcessName, SwapChainAddress) pairs and count occurrences
+            // Extract only the two fields needed here. Splitting every row into every CSV
+            // column doubles most of the parser's allocations before the real parse begins.
             var processSwapChainCounts = new Dictionary<(string ProcessName, string SwapChain), int>();
-            var lineData = new List<(string Line, string ProcessName, string SwapChain)>();
+            var pairOrder = new List<(string ProcessName, string SwapChain)>();
 
             foreach (var line in linesList)
             {
-                var values = line.Split(',');
-                if (values.Length <= Math.Max(swapChainIndex, processNameIndex))
+                if (!TryGetCsvFields(line, processNameIndex, swapChainIndex,
+                    out var processName, out var swapChain))
+                {
                     continue;
+                }
 
-                var processName = values[processNameIndex];
-                var swapChain = values[swapChainIndex];
                 var key = (processName, swapChain);
 
-                if (!processSwapChainCounts.ContainsKey(key))
-                    processSwapChainCounts[key] = 0;
-                processSwapChainCounts[key]++;
-
-                lineData.Add((line, processName, swapChain));
+                if (processSwapChainCounts.TryGetValue(key, out var count))
+                {
+                    processSwapChainCounts[key] = count + 1;
+                }
+                else
+                {
+                    processSwapChainCounts[key] = 1;
+                    pairOrder.Add(key);
+                }
             }
 
-            if (!processSwapChainCounts.Any())
+            if (processSwapChainCounts.Count == 0)
                 return linesList;
 
-            // Group by process and find the dominant SwapChain for each process
-            var processCounts = processSwapChainCounts
-                .GroupBy(kvp => kvp.Key.ProcessName)
-                .ToDictionary(
-                    g => g.Key,
-                    g => new
-                    {
-                        TotalFrames = g.Sum(x => x.Value),
-                        DominantSwapChain = g.OrderByDescending(x => x.Value).First().Key.SwapChain,
-                        DominantSwapChainCount = g.OrderByDescending(x => x.Value).First().Value
-                    });
+            var processOrder = new List<string>();
+            var processTotals = new Dictionary<string, int>();
+            var dominantPairs = new Dictionary<string, (string SwapChain, int Count)>();
+            foreach (var pair in pairOrder)
+            {
+                int count = processSwapChainCounts[pair];
+                if (processTotals.TryGetValue(pair.ProcessName, out var total))
+                {
+                    processTotals[pair.ProcessName] = total + count;
+                }
+                else
+                {
+                    processTotals[pair.ProcessName] = count;
+                    processOrder.Add(pair.ProcessName);
+                }
 
-            // Select the dominant process (the one with the most frames from its dominant SwapChain)
-            var dominantProcess = processCounts
-                .OrderByDescending(p => p.Value.DominantSwapChainCount)
-                .First();
+                if (!dominantPairs.TryGetValue(pair.ProcessName, out var dominant)
+                    || count > dominant.Count)
+                {
+                    dominantPairs[pair.ProcessName] = (pair.SwapChain, count);
+                }
+            }
 
-            var selectedProcessName = dominantProcess.Key;
-            var selectedSwapChain = dominantProcess.Value.DominantSwapChain;
+            string selectedProcessName = processOrder[0];
+            var selectedDominant = dominantPairs[selectedProcessName];
+            foreach (var processName in processOrder.Skip(1))
+            {
+                var candidate = dominantPairs[processName];
+                if (candidate.Count > selectedDominant.Count)
+                {
+                    selectedProcessName = processName;
+                    selectedDominant = candidate;
+                }
+            }
+
+            var selectedSwapChain = selectedDominant.SwapChain;
 
             _logger.LogInformation($"SwapChain filtering: Selected process '{selectedProcessName}' with SwapChain '{selectedSwapChain}' " +
-                $"({dominantProcess.Value.DominantSwapChainCount} frames out of {dominantProcess.Value.TotalFrames} total for this process)");
+                $"({selectedDominant.Count} frames out of {processTotals[selectedProcessName]} total for this process)");
 
             // Log if we're filtering out other processes or swap chains
-            if (processCounts.Count > 1)
+            if (processOrder.Count > 1)
             {
-                _logger.LogInformation($"SwapChain filtering: Filtered out {processCounts.Count - 1} other process(es)");
+                _logger.LogInformation($"SwapChain filtering: Filtered out {processOrder.Count - 1} other process(es)");
             }
 
             var otherSwapChainsForProcess = processSwapChainCounts
@@ -1307,12 +1707,205 @@ namespace CapFrameX.Data
             }
 
             // Filter lines to only include the selected process and SwapChain
-            var filteredLines = lineData
-                .Where(ld => ld.ProcessName == selectedProcessName && ld.SwapChain == selectedSwapChain)
-                .Select(ld => ld.Line)
-                .ToList();
+            var filteredLines = new List<string>(selectedDominant.Count);
+            foreach (var line in linesList)
+            {
+                if (TryGetCsvFields(line, processNameIndex, swapChainIndex,
+                    out var processName, out var swapChain)
+                    && processName == selectedProcessName
+                    && swapChain == selectedSwapChain)
+                {
+                    filteredLines.Add(line);
+                }
+            }
 
             return filteredLines;
+        }
+
+        private static bool TryGetCsvFields(string line, int firstIndex, int secondIndex,
+            out string firstValue, out string secondValue)
+        {
+            firstValue = null;
+            secondValue = null;
+            int highestIndex = Math.Max(firstIndex, secondIndex);
+            int position = 0;
+
+            for (int fieldIndex = 0; fieldIndex <= highestIndex; fieldIndex++)
+            {
+                bool required = fieldIndex == firstIndex || fieldIndex == secondIndex;
+                if (!TryReadCsvField(line, ref position, required, out var value))
+                {
+                    return false;
+                }
+
+                if (fieldIndex == firstIndex)
+                {
+                    firstValue = value;
+                }
+                if (fieldIndex == secondIndex)
+                {
+                    secondValue = value;
+                }
+            }
+
+            return true;
+        }
+
+        private static void MarkRequiredColumns(bool[] requiredColumns, params int[] indices)
+        {
+            foreach (int index in indices)
+            {
+                if (index >= 0 && index < requiredColumns.Length)
+                {
+                    requiredColumns[index] = true;
+                }
+            }
+        }
+
+        private static void ParseCsvFields(string line, string[] values, bool[] requiredColumns)
+        {
+            Array.Clear(values, 0, values.Length);
+            int position = 0;
+            for (int fieldIndex = 0; fieldIndex < values.Length; fieldIndex++)
+            {
+                if (!TryReadCsvField(line, ref position, requiredColumns[fieldIndex], out var value))
+                {
+                    return;
+                }
+
+                if (requiredColumns[fieldIndex])
+                {
+                    values[fieldIndex] = value;
+                }
+            }
+        }
+
+        private static bool TryReadCsvField(string line, ref int position, bool materialize, out string value)
+        {
+            value = null;
+            if (line == null || position > line.Length)
+            {
+                return false;
+            }
+
+            if (position < line.Length && line[position] == '"')
+            {
+                position++;
+                int segmentStart = position;
+                StringBuilder builder = materialize ? new StringBuilder() : null;
+                bool closed = false;
+
+                while (position < line.Length)
+                {
+                    if (line[position] != '"')
+                    {
+                        position++;
+                        continue;
+                    }
+
+                    if (position + 1 < line.Length && line[position + 1] == '"')
+                    {
+                        if (materialize)
+                        {
+                            builder.Append(line, segmentStart, position - segmentStart);
+                            builder.Append('"');
+                        }
+                        position += 2;
+                        segmentStart = position;
+                        continue;
+                    }
+
+                    if (materialize)
+                    {
+                        builder.Append(line, segmentStart, position - segmentStart);
+                    }
+                    position++;
+                    closed = true;
+                    break;
+                }
+
+                if (!closed && materialize)
+                {
+                    builder.Append(line, segmentStart, position - segmentStart);
+                }
+
+                while (position < line.Length && line[position] != ',')
+                {
+                    if (materialize)
+                    {
+                        builder.Append(line[position]);
+                    }
+                    position++;
+                }
+
+                if (materialize)
+                {
+                    value = builder.ToString();
+                }
+            }
+            else
+            {
+                int fieldStart = position;
+                while (position < line.Length && line[position] != ',')
+                {
+                    position++;
+                }
+
+                if (materialize)
+                {
+                    value = line.Substring(fieldStart, position - fieldStart);
+                }
+            }
+
+            if (position < line.Length && line[position] == ',')
+            {
+                position++;
+            }
+            else
+            {
+                position = line.Length + 1;
+            }
+
+            return true;
+        }
+
+        private static string GetPresentLinesSha1(IList<string> lines)
+        {
+            var encoding = Encoding.ASCII;
+            var buffer = new byte[256];
+            var delimiter = new byte[] { (byte)',' };
+
+            using (var sha1 = new SHA1Managed())
+            {
+                for (int i = 0; i < lines.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        sha1.TransformBlock(delimiter, 0, delimiter.Length, delimiter, 0);
+                    }
+
+                    string line = lines[i] ?? string.Empty;
+                    int requiredLength = encoding.GetMaxByteCount(line.Length);
+                    if (buffer.Length < requiredLength)
+                    {
+                        buffer = new byte[requiredLength];
+                    }
+
+                    int byteCount = encoding.GetBytes(line, 0, line.Length, buffer, 0);
+                    if (byteCount > 0)
+                    {
+                        sha1.TransformBlock(buffer, 0, byteCount, buffer, 0);
+                    }
+                }
+
+                sha1.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                var hash = new StringBuilder(sha1.Hash.Length * 2);
+                foreach (byte value in sha1.Hash)
+                {
+                    hash.Append(value.ToString("X2"));
+                }
+                return hash.ToString();
+            }
         }
 
         public void NormalizeStartTimesOfSessionRuns(IEnumerable<ISessionRun> sessionRuns)

--- a/source/CapFrameX.Test/CapFrameX.Test.csproj
+++ b/source/CapFrameX.Test/CapFrameX.Test.csproj
@@ -76,6 +76,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Data\CaptureManagerTest.cs" />
+    <Compile Include="Data\RecordManagerCacheTest.cs" />
     <Compile Include="Integration\PresentMonIntegrationTest.cs" />
     <Compile Include="Data\FileRecordInfoTest.cs" />
     <Compile Include="Extensions\ObservableExtensionsTest.cs" />

--- a/source/CapFrameX.Test/Data/RecordManagerCacheTest.cs
+++ b/source/CapFrameX.Test/Data/RecordManagerCacheTest.cs
@@ -1,0 +1,305 @@
+using CapFrameX.Data;
+using CapFrameX.Data.Session.Contracts;
+using CapFrameX.Configuration;
+using CapFrameX.Contracts.Configuration;
+using CapFrameX.Contracts.Data;
+using CapFrameX.Extensions;
+using CapFrameX.Test.Mocks;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Prism.Events;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace CapFrameX.Test.Data
+{
+    [TestClass]
+    public class RecordManagerCacheTest
+    {
+        private string _testDirectory;
+        private RecordManager _recordManager;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _testDirectory = Path.Combine(Path.GetTempPath(), "CapFrameX.RecordCacheTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_testDirectory);
+            _recordManager = CreateRecordManager();
+        }
+
+        private static RecordManager CreateRecordManager(ProcessList processList = null)
+        {
+            return new RecordManager(
+                new Mock<ILogger<RecordManager>>().Object,
+                null,
+                null,
+                null,
+                null,
+                null,
+                processList,
+                null,
+                new EventAggregator(),
+                null);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (Directory.Exists(_testDirectory))
+            {
+                Directory.Delete(_testDirectory, true);
+            }
+        }
+
+        [TestMethod]
+        public void LoadData_UnchangedNormalizedPath_ReusesSession()
+        {
+            string path = CreateSessionFile("capture.json", "First.exe");
+            string equivalentPath = Path.Combine(_testDirectory, ".", "capture.json");
+
+            ISession first = _recordManager.LoadData(path);
+            ISession second = _recordManager.LoadData(equivalentPath);
+
+            Assert.IsNotNull(first);
+            Assert.AreSame(first, second);
+        }
+
+        [TestMethod]
+        public void LoadData_ChangedFileStamp_ReloadsSession()
+        {
+            string path = CreateSessionFile("capture.json", "First.exe");
+            ISession first = _recordManager.LoadData(path);
+
+            DateTime changedStamp = File.GetLastWriteTimeUtc(path).AddSeconds(2);
+            File.WriteAllText(path, CreateSessionJson("Other.exe"));
+            File.SetLastWriteTimeUtc(path, changedStamp);
+
+            ISession second = _recordManager.LoadData(path);
+
+            Assert.IsNotNull(first);
+            Assert.IsNotNull(second);
+            Assert.AreNotSame(first, second);
+            Assert.AreEqual("Other.exe", second.Info.ProcessName);
+        }
+
+        [TestMethod]
+        public async Task LoadData_ConcurrentRequests_ShareSession()
+        {
+            string path = CreateSessionFile("capture.json", "First.exe");
+            var loads = Enumerable.Range(0, 12)
+                .Select(_ => Task.Run(() => _recordManager.LoadData(path)))
+                .ToArray();
+
+            ISession[] sessions = await Task.WhenAll(loads);
+
+            Assert.IsTrue(sessions.All(session => session != null));
+            Assert.IsTrue(sessions.All(session => ReferenceEquals(sessions[0], session)));
+        }
+
+        [TestMethod]
+        public void IncrementalPresentHash_MatchesLegacyContract()
+        {
+            var cases = new[]
+            {
+                new string[0],
+                new[] { "single" },
+                new[] { "first", "second", "third" },
+                new[] { "first", string.Empty, "third" },
+                new[] { "embedded,comma", "\u00e4\ud83d\ude80" }
+            };
+            var method = typeof(RecordManager).GetMethod("GetPresentLinesSha1",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.IsNotNull(method);
+            foreach (var lines in cases)
+            {
+                string expected = string.Join(",", lines).GetSha1();
+                string actual = (string)method.Invoke(null, new object[] { lines });
+                Assert.AreEqual(expected, actual);
+            }
+            Assert.AreEqual("DA39A3EE5E6B4B0D3255BFEF95601890AFD80709",
+                (string)method.Invoke(null, new object[] { new string[0] }));
+        }
+
+        [TestMethod]
+        public void ConvertPresentData_DominantSwapChain_PreservesSelectedRowsAndValues()
+        {
+            var recordManager = new RecordManager(
+                new Mock<ILogger<RecordManager>>().Object,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                new EventAggregator(),
+                new MockCaptureService());
+            const string header = "Application,ProcessID,SwapChainAddress,TimeInSeconds,MsBetweenPresents,MsBetweenDisplayChange";
+            var selectedRows = new[]
+            {
+                "P2,2,C,10.00,20,21",
+                "P2,2,C,10.02,22,23",
+                "P2,2,C,10.04,24,25",
+                "P2,2,C,10.06,26,27"
+            };
+            var lines = new List<string> { header };
+            lines.AddRange(new[]
+            {
+                "P1,1,A,1.00,10,11",
+                "P1,1,A,1.01,10,11",
+                "P1,1,A,1.02,10,11",
+                "P1,1,B,2.00,12,13",
+                "P1,1,B,2.01,12,13"
+            });
+            lines.AddRange(selectedRows);
+
+            var run = recordManager.ConvertPresentDataLinesToSessionRun(lines);
+
+            Assert.AreEqual(string.Join(",", selectedRows).GetSha1(), run.Hash);
+            CollectionAssert.AreEqual(new[] { 20d, 22d, 24d, 26d }, run.CaptureData.MsBetweenPresents);
+            CollectionAssert.AreEqual(new[] { 21d, 23d, 25d, 27d }, run.CaptureData.MsBetweenDisplayChange);
+            var expectedTimes = new[] { 0d, 0.02d, 0.04d, 0.06d };
+            for (int i = 0; i < expectedTimes.Length; i++)
+            {
+                Assert.AreEqual(expectedTimes[i], run.CaptureData.TimeInSeconds[i], 1E-12);
+            }
+            Assert.IsTrue(run.CaptureData.AnimationError.All(double.IsNaN));
+        }
+
+        [TestMethod]
+        public async Task GetFileRecordInfo_JsonMetadataScan_MatchesFullSessionAndCachesResult()
+        {
+            string path = Path.Combine(_testDirectory, "metadata.json");
+            File.WriteAllText(path,
+                "{\"Hash\":\"SESSION-HASH\",\"Info\":{" +
+                "\"Id\":\"8f9f8c95-f1c1-4a38-90b4-61c74a40df35\"," +
+                "\"CreationDate\":\"2026-07-18T12:00:00Z\",\"ProcessName\":\"Game.exe\"," +
+                "\"GameName\":\"Game Display\",\"Processor\":\"CPU\",\"GPU\":\"GPU\"," +
+                "\"SystemRam\":\"32 GB\",\"Comment\":\"metadata\"}," +
+                "\"Runs\":[" +
+                "{\"CaptureData\":{\"TimeInSeconds\":[0.0,1.25],\"MsBetweenPresents\":[16.0,17.0]}}," +
+                "{\"CaptureData\":{\"TimeInSeconds\":[1.25,2.75],\"MsBetweenPresents\":[18.0,19.0]}}]}");
+            var fileInfo = new FileInfo(path);
+
+            var lightweight = await _recordManager.GetFileRecordInfo(fileInfo);
+            var cached = await _recordManager.GetFileRecordInfo(new FileInfo(path));
+            var fullSession = _recordManager.LoadData(path);
+            var full = FileRecordInfo.Create(fileInfo, fullSession);
+
+            Assert.IsNotNull(lightweight);
+            Assert.AreSame(lightweight, cached);
+            Assert.AreEqual(full.Hash, lightweight.Hash);
+            Assert.AreEqual(full.Id, lightweight.Id);
+            Assert.AreEqual(full.ProcessName, lightweight.ProcessName);
+            Assert.AreEqual(full.GameName, lightweight.GameName);
+            Assert.AreEqual(full.ProcessorName, lightweight.ProcessorName);
+            Assert.AreEqual(full.GraphicCardName, lightweight.GraphicCardName);
+            Assert.AreEqual(full.SystemRamInfo, lightweight.SystemRamInfo);
+            Assert.AreEqual(full.Comment, lightweight.Comment);
+            Assert.AreEqual(full.IsAggregated, lightweight.IsAggregated);
+            Assert.AreEqual(2.75, lightweight.RecordTime, 1E-12);
+        }
+
+        [TestMethod]
+        public async Task GetFileRecordInfo_ProcessListNameChanged_RefreshesMemoryCache()
+        {
+            var processList = (ProcessList)Activator.CreateInstance(typeof(ProcessList),
+                BindingFlags.Instance | BindingFlags.NonPublic, null,
+                new object[]
+                {
+                    Path.Combine(_testDirectory, "processes.json"),
+                    new Mock<IAppConfiguration>().Object,
+                    new Mock<ILogger<ProcessList>>().Object
+                }, null);
+            processList.AddEntry("RenameMe.exe", "First Name");
+            var manager = CreateRecordManager(processList);
+            string path = CreateMetadataSessionFile("rename.json", "RenameMe.exe", "RenameMe.exe");
+
+            var first = await manager.GetFileRecordInfo(new FileInfo(path));
+            Assert.AreEqual("First Name", first.GameName);
+
+            processList.FindProcessByName("RenameMe.exe").UpdateDisplayName("Second Name");
+            var memoryCached = await manager.GetFileRecordInfo(new FileInfo(path));
+
+            Assert.AreEqual("Second Name", memoryCached.GameName);
+        }
+
+        [TestMethod]
+        public async Task GetFileRecordInfo_IncompleteJsonMetadata_ReturnsNull()
+        {
+            string infoOnlyPath = Path.Combine(_testDirectory, "info-only.json");
+            string runsOnlyPath = Path.Combine(_testDirectory, "runs-only.json");
+            File.WriteAllText(infoOnlyPath,
+                "{\"Hash\":\"hash\",\"Info\":{\"ProcessName\":\"MissingRuns.exe\"}}");
+            File.WriteAllText(runsOnlyPath,
+                "{\"Hash\":\"hash\",\"Runs\":[{\"CaptureData\":{\"TimeInSeconds\":[0,1]}}]}");
+
+            var infoOnly = await _recordManager.GetFileRecordInfo(new FileInfo(infoOnlyPath));
+            var runsOnly = await _recordManager.GetFileRecordInfo(new FileInfo(runsOnlyPath));
+
+            Assert.IsNull(infoOnly);
+            Assert.IsNull(runsOnly);
+        }
+
+        [TestMethod]
+        public void ConvertPresentData_QuotedCsvFields_FilterAndParseCorrectly()
+        {
+            var recordManager = new RecordManager(
+                new Mock<ILogger<RecordManager>>().Object,
+                null, null, null, null, null, null, null,
+                new EventAggregator(), new MockCaptureService());
+            const string header = "Application,ProcessID,SwapChainAddress,TimeInSeconds,MsBetweenPresents,MsBetweenDisplayChange";
+            var selectedRows = new[]
+            {
+                "\"P,One\",1,\"A,1\",\"10.00\",\"20\",\"21\"",
+                "\"P,One\",1,\"A,1\",\"10.02\",\"22\",\"23\""
+            };
+            var lines = new List<string>
+            {
+                header,
+                "\"Other\",2,\"B\",1.0,11,12"
+            };
+            lines.AddRange(selectedRows);
+
+            var run = recordManager.ConvertPresentDataLinesToSessionRun(lines);
+
+            Assert.AreEqual(string.Join(",", selectedRows).GetSha1(), run.Hash);
+            CollectionAssert.AreEqual(new[] { 20d, 22d }, run.CaptureData.MsBetweenPresents);
+            CollectionAssert.AreEqual(new[] { 21d, 23d }, run.CaptureData.MsBetweenDisplayChange);
+            Assert.AreEqual(0d, run.CaptureData.TimeInSeconds[0], 1E-12);
+            Assert.AreEqual(0.02d, run.CaptureData.TimeInSeconds[1], 1E-12);
+        }
+
+        private string CreateSessionFile(string fileName, string processName)
+        {
+            string path = Path.Combine(_testDirectory, fileName);
+            File.WriteAllText(path, CreateSessionJson(processName));
+            return path;
+        }
+
+        private static string CreateSessionJson(string processName)
+        {
+            return "{\"Hash\":\"hash\",\"Info\":{\"ProcessName\":\"" + processName + "\"},\"Runs\":[]}";
+        }
+
+        private string CreateMetadataSessionFile(string fileName, string processName, string gameName)
+        {
+            string path = Path.Combine(_testDirectory, fileName);
+            File.WriteAllText(path,
+                "{\"Hash\":\"metadata-hash\",\"Info\":{" +
+                "\"Id\":\"8f9f8c95-f1c1-4a38-90b4-61c74a40df35\"," +
+                "\"CreationDate\":\"2026-07-18T12:00:00Z\"," +
+                "\"ProcessName\":\"" + processName + "\"," +
+                "\"GameName\":\"" + gameName + "\",\"Comment\":\"metadata\"}," +
+                "\"Runs\":[{\"CaptureData\":{\"TimeInSeconds\":[0.0,2.5]}}]}");
+            return path;
+        }
+
+    }
+}

--- a/source/CapFrameX.Test/Data/RecordManagerCacheTest.cs
+++ b/source/CapFrameX.Test/Data/RecordManagerCacheTest.cs
@@ -102,6 +102,24 @@ namespace CapFrameX.Test.Data
         }
 
         [TestMethod]
+        public async Task UpdateCustomData_JsonInvalidatesSessionAndMetadataCaches()
+        {
+            string path = CreateMetadataSessionFile("update.json", "Update.exe", "Update");
+            var session = _recordManager.LoadData(path);
+            var recordInfo = await _recordManager.GetFileRecordInfo(new FileInfo(path));
+
+            Assert.IsNotNull(session);
+            Assert.IsNotNull(recordInfo);
+            Assert.AreEqual(1, GetPrivateCacheCount("_sessionCache"));
+            Assert.AreEqual(1, GetPrivateCacheCount("_recordInfoCache"));
+
+            _recordManager.UpdateCustomData(recordInfo, "CPU", "GPU", "RAM", "Updated", "Comment");
+
+            Assert.AreEqual(0, GetPrivateCacheCount("_sessionCache"));
+            Assert.AreEqual(0, GetPrivateCacheCount("_recordInfoCache"));
+        }
+
+        [TestMethod]
         public void IncrementalPresentHash_MatchesLegacyContract()
         {
             var cases = new[]
@@ -299,6 +317,16 @@ namespace CapFrameX.Test.Data
                 "\"GameName\":\"" + gameName + "\",\"Comment\":\"metadata\"}," +
                 "\"Runs\":[{\"CaptureData\":{\"TimeInSeconds\":[0.0,2.5]}}]}");
             return path;
+        }
+
+        private int GetPrivateCacheCount(string fieldName)
+        {
+            var field = typeof(RecordManager).GetField(fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(field);
+            var cache = field.GetValue(_recordManager) as System.Collections.IDictionary;
+            Assert.IsNotNull(cache);
+            return cache.Count;
         }
 
     }


### PR DESCRIPTION
## Summary

This extracts the record parsing/loading work from #398 into a focused change, following the review request.

The goal is to reduce record-list I/O and repeated parsing while keeping cache behavior bounded, disposable, and validated against the source file.

## Changes

- Add a 16-entry weak session cache keyed by normalized path, file length, and last-write time.
- Share one `Lazy<ISession>` between concurrent callers loading the same unchanged capture.
- Invalidate session and metadata entries immediately after successful JSON/CSV application writes.
- Scan JSON metadata without deserializing frame and sensor payloads merely to populate the record list.
- Add a bounded 4,096-entry in-memory metadata cache with source-stamp validation.
- Refresh ProcessList-derived display names instead of freezing them in cached metadata.
- Parse only required CSV fields with quote-aware handling for quoted commas and escaped quotes.
- Use the same quote-aware reader in dominant-swap-chain selection and metric conversion.
- Reuse already-read CSV lines when constructing record metadata.
- Compute the selected-row SHA-1 incrementally while preserving the existing hash contract for ordinary captures.
- Reject incomplete JSON metadata instead of presenting records that cannot be analyzed.

## Deliberately excluded

- No persistent binary metadata index.
- No SQLite or database work.
- No new package/runtime dependency.
- No statistics, WPF, plotting, or build-tooling changes.

The persistent-index portion remains local because CapFrameX 2.0 plans to use SQLite.

## Regression coverage

Ten focused tests cover session reuse, stamp invalidation, concurrent sharing, immediate post-write cache invalidation, hash compatibility, dominant swap-chain behavior, JSON metadata parity/reuse, ProcessList renames, incomplete JSON, and quoted CSV fields.

## Validation

- x64 Release application build: passed, 0 errors.
- x64 Release test build: passed, 0 errors.
- Focused record-cache tests: 10/10 passed.
- The dependent record/index stack, which contains this exact base, passed 267 total tests: 262 passed, 5 hardware skips, 0 failed.
- `git diff --check`: passed.
- No package/dependency changes.

This PR is based directly on `v1.8.6` (`383bc029`).
