### PR TITLE
Improve legacy WPF visualization responsiveness

### DIFF
--- a/source/CapFrameX.Statistics.PlotBuilder/FpsGraphPlotBuilder.cs
+++ b/source/CapFrameX.Statistics.PlotBuilder/FpsGraphPlotBuilder.cs
@@ -16,9 +16,13 @@ namespace CapFrameX.Statistics.PlotBuilder
         public void BuildPlotmodel(ISession session, IPlotSettings plotSettings, double startTime, double endTime, ERemoveOutlierMethod eRemoveOutlinerMethod, EFilterMode filterMode, Action<PlotModel> onFinishAction = null)
         {
             var plotModel = PlotModel;
-            Reset();
+            Reset(false);
 
-            if (session == null) return;
+            if (session == null)
+            {
+                plotModel.InvalidatePlot(true);
+                return;
+            }
 
             plotModel.Axes.Add(AxisDefinitions[EPlotAxis.XAXIS]);
             plotModel.Axes.Add(AxisDefinitions[EPlotAxis.YAXISFPS]);
@@ -112,7 +116,6 @@ namespace CapFrameX.Statistics.PlotBuilder
             if (fpsPoints == null || !fpsPoints.Any())
                 return;
 
-            int count = fpsPoints.Count;
             var fpsDataPoints = fpsPoints.Select(pnt => new DataPoint(pnt.X, pnt.Y));
             var gpuActiveFpsDataPoints = gpuActiveFpsPoints.Select(pnt => new DataPoint(pnt.X, pnt.Y));
 
@@ -149,8 +152,6 @@ namespace CapFrameX.Statistics.PlotBuilder
             //    plotModel.Series.Add(gpuActiveFpsSeries);
             //}
 
-            var averageDataPoints = fpsPoints.Select(pnt => new DataPoint(pnt.X, average));
-
             var averageSeries = new LineSeries
             {
                 Title = "Avg FPS",
@@ -159,7 +160,8 @@ namespace CapFrameX.Statistics.PlotBuilder
                 Color = OxyColor.FromAColor(200, Constants.FpsAverageColor)
             };
 
-            averageSeries.Points.AddRange(averageDataPoints);
+            averageSeries.Points.Add(new DataPoint(fpsPoints.First().X, average));
+            averageSeries.Points.Add(new DataPoint(fpsPoints.Last().X, average));
             plotModel.Series.Add(averageSeries);
 
 
@@ -167,9 +169,7 @@ namespace CapFrameX.Statistics.PlotBuilder
             {
                 axis.Minimum = rawfpsPoints.First().X;
                 axis.Maximum = rawfpsPoints.Last().X;
-            });
-
-            plotModel.InvalidatePlot(true);
+            }, false);
         }
 
         private void SetRawFPS(PlotModel plotModel, IList<Point> fpsPoints)
@@ -186,19 +186,10 @@ namespace CapFrameX.Statistics.PlotBuilder
             var points = fpsPoints.Select(pnt => new DataPoint(pnt.X, pnt.Y));
             fpsSeries.Points.AddRange(points);
             plotModel.Series.Add(fpsSeries);
-
-            plotModel.InvalidatePlot(true);
         }
 
         private void SetThresholdChart(PlotModel plotModel, IPlotSettings plotSettings, IList<Point> fpspoints)
         {
-            var lowFPS = new List<double>();
-
-            for (int i = 0; i < fpspoints.Count; i++)
-            {
-                lowFPS.Add(plotSettings.LowFPSThreshold);
-            }
-
             var lowFPSSeries = new LineSeries
             {
                 Title = "LowFPS",
@@ -209,7 +200,8 @@ namespace CapFrameX.Statistics.PlotBuilder
                 EdgeRenderingMode = EdgeRenderingMode.PreferSpeed
             };
 
-            lowFPSSeries.Points.AddRange(lowFPS.Select((y, i) => new DataPoint(fpspoints[i].X, y)));
+            lowFPSSeries.Points.Add(new DataPoint(fpspoints.First().X, plotSettings.LowFPSThreshold));
+            lowFPSSeries.Points.Add(new DataPoint(fpspoints.Last().X, plotSettings.LowFPSThreshold));
             plotModel.Series.Add(lowFPSSeries);
         }
 
@@ -233,7 +225,7 @@ namespace CapFrameX.Statistics.PlotBuilder
                     axis.Maximum = average + 5;
                 else
                     axis.Maximum = axisMaximum;
-            });
+            }, false);
         }
 
     }

--- a/source/CapFrameX.Statistics.PlotBuilder/FrametimeDistributionPlotBuilder.cs
+++ b/source/CapFrameX.Statistics.PlotBuilder/FrametimeDistributionPlotBuilder.cs
@@ -18,10 +18,11 @@ namespace CapFrameX.Statistics.PlotBuilder
         public void BuildPlotmodel(ISession session, IPlotSettings plotSettings, double startTime, double endTime, ERemoveOutlierMethod eRemoveOutlinerMethod, Action<PlotModel> onFinishAction = null)
         {
             var plotModel = PlotModel;
-            Reset();
+            Reset(false);
 
             if (session == null)
             {
+                plotModel.InvalidatePlot(true);
                 return;
             }
 
@@ -102,10 +103,8 @@ namespace CapFrameX.Statistics.PlotBuilder
             {
                 axis.Minimum = frametimeDistributionPoints.First().X - 1;
                 axis.Maximum = frametimeDistributionPoints.Last().X + 1;
-            });
+            }, false);
             plotModel.Series.Add(distributionSeries);
-
-            plotModel.InvalidatePlot(true);
         }
 
         private void UpdateYAxisMaxBorder(double yMax)
@@ -129,7 +128,7 @@ namespace CapFrameX.Statistics.PlotBuilder
                      stepSize = 10;
 
                  axis.MajorStep = stepSize;
-             });
+             }, false);
         }
     }
 }

--- a/source/CapFrameX.Statistics.PlotBuilder/FrametimePlotBuilder.cs
+++ b/source/CapFrameX.Statistics.PlotBuilder/FrametimePlotBuilder.cs
@@ -16,10 +16,11 @@ namespace CapFrameX.Statistics.PlotBuilder
         public void BuildPlotmodel(ISession session, IPlotSettings plotSettings, double startTime, double endTime, ERemoveOutlierMethod eRemoveOutlinerMethod, Action<PlotModel> onFinishAction = null)
         {
             var plotModel = PlotModel;
-            Reset();
+            Reset(false);
 
             if (session == null)
             {
+                plotModel.InvalidatePlot(true);
                 return;
             }
 
@@ -102,12 +103,10 @@ namespace CapFrameX.Statistics.PlotBuilder
             }
 
             var stuttering = new List<double>();
-            var lowFPS = new List<double>();
 
             for (int i = 0; i < count; i++)
             {
                 stuttering.Add(movingAverageValues[i] * plotSettings.StutteringFactor);
-                lowFPS.Add(1000 / plotSettings.LowFPSThreshold);
             }
 
             plotModel.Series.Clear();
@@ -181,7 +180,7 @@ namespace CapFrameX.Statistics.PlotBuilder
             {
                 axis.Minimum = frametimePoints.First().X;
                 axis.Maximum = frametimePoints.Last().X;
-            });
+            }, false);
 
             plotModel.Series.Add(frametimeSeries);
             plotModel.Series.Add(movingAverageSeries);
@@ -195,13 +194,13 @@ namespace CapFrameX.Statistics.PlotBuilder
             if (plotSettings.ShowThresholds)
             {
                 stutteringSeries.Points.AddRange(stuttering.Select((y, i) => new DataPoint(frametimePoints[i].X, y)));
-                lowFPSSeries.Points.AddRange(lowFPS.Select((y, i) => new DataPoint(frametimePoints[i].X, y)));
+                double lowFpsThreshold = 1000 / plotSettings.LowFPSThreshold;
+                lowFPSSeries.Points.Add(new DataPoint(frametimePoints.First().X, lowFpsThreshold));
+                lowFPSSeries.Points.Add(new DataPoint(frametimePoints.Last().X, lowFpsThreshold));
 
                 plotModel.Series.Add(stutteringSeries);
                 plotModel.Series.Add(lowFPSSeries);
             }
-
-            plotModel.InvalidatePlot(true);
         }
     }
 }

--- a/source/CapFrameX.Statistics.PlotBuilder/LineSeries.cs
+++ b/source/CapFrameX.Statistics.PlotBuilder/LineSeries.cs
@@ -1,10 +1,127 @@
 ﻿using OxyPlot;
 
+using System;
+using System.Collections.Generic;
+
 namespace CapFrameX.Statistics.PlotBuilder
 {
     public class LineSeries: OxyPlot.Series.LineSeries
 	{
 		public int LegendStrokeThickness { get; set; }
+
+        public LineSeries()
+        {
+            // OxyPlot passes transformed screen coordinates to the decimator.
+            // Keep the raw data intact for zooming, tracking and exporting.
+            Decimator = DecimateScreenPoints;
+            MinimumSegmentLength = 0;
+        }
+
+        public static void DecimateScreenPoints(List<ScreenPoint> input, List<ScreenPoint> output)
+        {
+            if (input == null || output == null || input.Count == 0)
+                return;
+
+            int runStart = 0;
+            while (runStart < input.Count)
+            {
+                if (!IsFinite(input[runStart]))
+                {
+                    AddDistinct(output, input[runStart]);
+                    runStart++;
+                    continue;
+                }
+
+                int runEnd = runStart + 1;
+                while (runEnd < input.Count && IsFinite(input[runEnd]))
+                    runEnd++;
+
+                DecimateFiniteRun(input, output, runStart, runEnd);
+                runStart = runEnd;
+            }
+        }
+
+        private static void DecimateFiniteRun(IList<ScreenPoint> input, IList<ScreenPoint> output,
+            int runStart, int runEnd)
+        {
+            int count = runEnd - runStart;
+            if (count <= 2)
+            {
+                for (int i = runStart; i < runEnd; i++)
+                    AddDistinct(output, input[i]);
+                return;
+            }
+
+            AddDistinct(output, input[runStart]);
+            int index = runStart + 1;
+            int lastIndex = runEnd - 1;
+
+            while (index < lastIndex)
+            {
+                int pixelColumn = GetPixelColumn(input[index].X);
+                int minimumIndex = index;
+                int maximumIndex = index;
+                int groupEnd = index + 1;
+
+                while (groupEnd < lastIndex && GetPixelColumn(input[groupEnd].X) == pixelColumn)
+                {
+                    if (input[groupEnd].Y < input[minimumIndex].Y)
+                        minimumIndex = groupEnd;
+
+                    if (input[groupEnd].Y > input[maximumIndex].Y)
+                        maximumIndex = groupEnd;
+
+                    groupEnd++;
+                }
+
+                if (minimumIndex <= maximumIndex)
+                {
+                    AddDistinct(output, input[minimumIndex]);
+                    AddDistinct(output, input[maximumIndex]);
+                }
+                else
+                {
+                    AddDistinct(output, input[maximumIndex]);
+                    AddDistinct(output, input[minimumIndex]);
+                }
+
+                index = groupEnd;
+            }
+
+            AddDistinct(output, input[lastIndex]);
+        }
+
+        private static int GetPixelColumn(double x)
+        {
+            if (x <= int.MinValue)
+                return int.MinValue;
+            if (x >= int.MaxValue)
+                return int.MaxValue;
+
+            return (int)Math.Floor(x);
+        }
+
+        private static bool IsFinite(ScreenPoint point)
+            => !double.IsNaN(point.X) && !double.IsInfinity(point.X)
+                && !double.IsNaN(point.Y) && !double.IsInfinity(point.Y);
+
+        private static void AddDistinct(IList<ScreenPoint> output, ScreenPoint point)
+        {
+            if (output.Count == 0)
+            {
+                output.Add(point);
+                return;
+            }
+
+            ScreenPoint previous = output[output.Count - 1];
+            if ((!IsFinite(previous) && !IsFinite(point))
+                || (previous.X == point.X && previous.Y == point.Y))
+            {
+                return;
+            }
+
+            output.Add(point);
+        }
 
         public override void RenderLegend(IRenderContext rc, OxyRect legendBox)
         {

--- a/source/CapFrameX.Statistics.PlotBuilder/PlotBuilder.cs
+++ b/source/CapFrameX.Statistics.PlotBuilder/PlotBuilder.cs
@@ -196,20 +196,22 @@ namespace CapFrameX.Statistics.PlotBuilder
             }
         };
 
-        public void Reset()
+        public void Reset(bool invalidatePlot = true)
         {
             PlotModel.Series.Clear();
             PlotModel.Axes.Clear();
-            PlotModel.InvalidatePlot(true);
+            if (invalidatePlot)
+                PlotModel.InvalidatePlot(true);
         }
 
-        public void UpdateAxis(EPlotAxis axisType, Action<Axis> action)
+        public void UpdateAxis(EPlotAxis axisType, Action<Axis> action, bool invalidatePlot = true)
         {
             var axis = PlotModel.GetAxisOrDefault(axisType.GetDescription(), null);
             if (axis != null)
             {
                 action(axis);
-                PlotModel.InvalidatePlot(false);
+                if (invalidatePlot)
+                    PlotModel.InvalidatePlot(false);
             }
         }
 

--- a/source/CapFrameX.Test/CapFrameX.Test.csproj
+++ b/source/CapFrameX.Test/CapFrameX.Test.csproj
@@ -102,6 +102,7 @@
     <Compile Include="TestHelper.cs" />
     <Compile Include="Updater\UpdateCheckTest.cs" />
     <Compile Include="ViewModel\CaptureViewModelTest.cs" />
+    <Compile Include="ViewModel\ComparisonSeriesBoundsTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestRecordFiles\CustomFilenameWithoutComment.csv">

--- a/source/CapFrameX.Test/CapFrameX.Test.csproj
+++ b/source/CapFrameX.Test/CapFrameX.Test.csproj
@@ -97,6 +97,8 @@
     <Compile Include="Sensor\PantherLakeVoltageTest.cs" />
     <Compile Include="Statistics\CircularBufferTest.cs" />
     <Compile Include="Statistics\FrametimeStatisticProviderTest.cs" />
+    <Compile Include="Statistics\LineSeriesDecimationTest.cs" />
+    <Compile Include="Statistics\PlotBuilderRenderingTest.cs" />
     <Compile Include="TestHelper.cs" />
     <Compile Include="Updater\UpdateCheckTest.cs" />
     <Compile Include="ViewModel\CaptureViewModelTest.cs" />
@@ -184,6 +186,10 @@
     <ProjectReference Include="..\CapFrameX.Statistics.NetStandard\CapFrameX.Statistics.NetStandard.csproj">
       <Project>{dc30f7f7-5725-4de9-b271-0d621b559cd5}</Project>
       <Name>CapFrameX.Statistics.NetStandard</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\CapFrameX.Statistics.PlotBuilder\CapFrameX.Statistics.PlotBuilder.csproj">
+      <Project>{80a26f08-6ae5-472d-bb13-b6fb9a37fdcb}</Project>
+      <Name>CapFrameX.Statistics.PlotBuilder</Name>
     </ProjectReference>
     <ProjectReference Include="..\CapFrameX.Updater\CapFrameX.Updater.csproj">
       <Project>{5d12aa37-cc30-4476-94ad-11c15dc65518}</Project>

--- a/source/CapFrameX.Test/Statistics/LineSeriesDecimationTest.cs
+++ b/source/CapFrameX.Test/Statistics/LineSeriesDecimationTest.cs
@@ -1,0 +1,81 @@
+using CapFrameX.Statistics.PlotBuilder;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OxyPlot;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CapFrameX.Test.Statistics
+{
+    [TestClass]
+    public class LineSeriesDecimationTest
+    {
+        [TestMethod]
+        public void DecimateScreenPoints_PreservesEndpointsAndPixelExtrema()
+        {
+            var input = new List<ScreenPoint>
+            {
+                new ScreenPoint(0.1, 5),
+                new ScreenPoint(0.2, 10),
+                new ScreenPoint(0.3, -20),
+                new ScreenPoint(0.4, 30),
+                new ScreenPoint(1.1, 8),
+                new ScreenPoint(1.2, -4),
+                new ScreenPoint(2.1, 7)
+            };
+            var output = new List<ScreenPoint>();
+
+            LineSeries.DecimateScreenPoints(input, output);
+
+            Assert.AreEqual(input.First(), output.First());
+            Assert.AreEqual(input.Last(), output.Last());
+            Assert.IsTrue(output.Contains(new ScreenPoint(0.3, -20)));
+            Assert.IsTrue(output.Contains(new ScreenPoint(0.4, 30)));
+            Assert.IsTrue(output.Contains(new ScreenPoint(1.2, -4)));
+            Assert.IsTrue(output.Count < input.Count);
+        }
+
+        [TestMethod]
+        public void DecimateScreenPoints_TwoPoints_PreservesBoth()
+        {
+            var input = new List<ScreenPoint>
+            {
+                new ScreenPoint(1, 10),
+                new ScreenPoint(2, 20)
+            };
+            var output = new List<ScreenPoint>();
+
+            LineSeries.DecimateScreenPoints(input, output);
+
+            CollectionAssert.AreEqual(input, output);
+        }
+
+        [TestMethod]
+        public void DecimateScreenPoints_Gap_PreservesSeparatedRunsAndExtrema()
+        {
+            var gap = new ScreenPoint(double.NaN, double.NaN);
+            var input = new List<ScreenPoint>
+            {
+                new ScreenPoint(0.1, 0),
+                new ScreenPoint(0.2, -10),
+                new ScreenPoint(0.3, 20),
+                new ScreenPoint(1.1, 1),
+                gap,
+                new ScreenPoint(2.1, 2),
+                new ScreenPoint(2.2, -30),
+                new ScreenPoint(2.3, 40),
+                new ScreenPoint(3.1, 3)
+            };
+            var output = new List<ScreenPoint>();
+
+            LineSeries.DecimateScreenPoints(input, output);
+
+            int gapIndex = output.FindIndex(point => double.IsNaN(point.X) && double.IsNaN(point.Y));
+            Assert.IsTrue(gapIndex > 0 && gapIndex < output.Count - 1);
+            Assert.IsTrue(output.Take(gapIndex).Contains(new ScreenPoint(0.2, -10)));
+            Assert.IsTrue(output.Take(gapIndex).Contains(new ScreenPoint(0.3, 20)));
+            Assert.IsTrue(output.Skip(gapIndex + 1).Contains(new ScreenPoint(2.2, -30)));
+            Assert.IsTrue(output.Skip(gapIndex + 1).Contains(new ScreenPoint(2.3, 40)));
+        }
+    }
+}

--- a/source/CapFrameX.Test/Statistics/PlotBuilderRenderingTest.cs
+++ b/source/CapFrameX.Test/Statistics/PlotBuilderRenderingTest.cs
@@ -1,0 +1,78 @@
+using CapFrameX.Data.Session.Classes;
+using CapFrameX.Statistics.NetStandard;
+using CapFrameX.Statistics.NetStandard.Contracts;
+using CapFrameX.Statistics.PlotBuilder;
+using CapFrameX.Statistics.PlotBuilder.Contracts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Linq;
+
+namespace CapFrameX.Test.Statistics
+{
+    [TestClass]
+    public class PlotBuilderRenderingTest
+    {
+        [TestMethod]
+        public void FpsGraph_ConstantReferenceLines_UseTwoPoints()
+        {
+            var context = CreateContext();
+            var builder = new FpsGraphPlotBuilder(context.Options.Object, context.Provider);
+
+            builder.BuildPlotmodel(context.Session, context.PlotSettings.Object, 0, 2,
+                ERemoveOutlierMethod.None, EFilterMode.None);
+
+            Assert.AreEqual(2, GetSeries(builder, "Avg FPS").Points.Count);
+            Assert.AreEqual(2, GetSeries(builder, "LowFPS").Points.Count);
+        }
+
+        [TestMethod]
+        public void FrametimeGraph_LowFpsReferenceLine_UsesTwoPoints()
+        {
+            var context = CreateContext();
+            var builder = new FrametimePlotBuilder(context.Options.Object, context.Provider);
+
+            builder.BuildPlotmodel(context.Session, context.PlotSettings.Object, 0, 2,
+                ERemoveOutlierMethod.None);
+
+            Assert.AreEqual(2, GetSeries(builder, "Low FPS").Points.Count);
+        }
+
+        private static OxyPlot.Series.LineSeries GetSeries(PlotBuilder builder, string title)
+            => builder.PlotModel.Series.OfType<OxyPlot.Series.LineSeries>()
+                .Single(series => series.Title == title);
+
+        private static TestContext CreateContext()
+        {
+            var options = new Mock<IFrametimeStatisticProviderOptions>();
+            options.SetupGet(value => value.FpsValuesRoundingDigits).Returns(2);
+            options.SetupGet(value => value.IntervalAverageWindowTime).Returns(500);
+            var plotSettings = new Mock<IPlotSettings>();
+            plotSettings.SetupGet(value => value.ShowThresholds).Returns(true);
+            plotSettings.SetupGet(value => value.LowFPSThreshold).Returns(30);
+            var captureData = new SessionCaptureData(3)
+            {
+                TimeInSeconds = new[] { 0d, 1d, 2d },
+                MsBetweenPresents = new[] { 10d, 20d, 40d },
+                MsBetweenDisplayChange = new[] { 0d, 0d, 0d }
+            };
+            var session = new Session();
+            session.Runs.Add(new SessionRun { CaptureData = captureData });
+
+            return new TestContext
+            {
+                Options = options,
+                PlotSettings = plotSettings,
+                Provider = new FrametimeStatisticProvider(options.Object),
+                Session = session
+            };
+        }
+
+        private sealed class TestContext
+        {
+            public Mock<IFrametimeStatisticProviderOptions> Options { get; set; }
+            public Mock<IPlotSettings> PlotSettings { get; set; }
+            public FrametimeStatisticProvider Provider { get; set; }
+            public Session Session { get; set; }
+        }
+    }
+}

--- a/source/CapFrameX.Test/ViewModel/ComparisonSeriesBoundsTest.cs
+++ b/source/CapFrameX.Test/ViewModel/ComparisonSeriesBoundsTest.cs
@@ -1,0 +1,55 @@
+using CapFrameX.ViewModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OxyPlot;
+using OxyPlot.Series;
+using System.Reflection;
+
+namespace CapFrameX.Test.ViewModel
+{
+    [TestClass]
+    public class ComparisonSeriesBoundsTest
+    {
+        [TestMethod]
+        public void TryGetSeriesBounds_UsesRenderedFinitePoints()
+        {
+            var model = new PlotModel();
+            var first = new LineSeries();
+            first.Points.Add(new DataPoint(1, 10));
+            first.Points.Add(new DataPoint(2, double.PositiveInfinity));
+            first.Points.Add(new DataPoint(3, -5));
+            var second = new LineSeries();
+            second.Points.Add(new DataPoint(-2, 4));
+            second.Points.Add(new DataPoint(double.NaN, 100));
+            model.Series.Add(first);
+            model.Series.Add(second);
+
+            var method = typeof(ComparisonViewModel).GetMethod("TryGetSeriesBounds",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            var arguments = new object[] { model, 0d, 0d, 0d, 0d };
+
+            bool result = (bool)method.Invoke(null, arguments);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(-2d, (double)arguments[1]);
+            Assert.AreEqual(3d, (double)arguments[2]);
+            Assert.AreEqual(-5d, (double)arguments[3]);
+            Assert.AreEqual(10d, (double)arguments[4]);
+        }
+
+        [TestMethod]
+        public void TryGetSeriesBounds_NoFinitePoints_ReturnsFalse()
+        {
+            var model = new PlotModel();
+            var series = new LineSeries();
+            series.Points.Add(new DataPoint(double.NaN, double.NaN));
+            model.Series.Add(series);
+            var method = typeof(ComparisonViewModel).GetMethod("TryGetSeriesBounds",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            var arguments = new object[] { model, 0d, 0d, 0d, 0d };
+
+            bool result = (bool)method.Invoke(null, arguments);
+
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/source/CapFrameX.View/AggregationView.xaml
+++ b/source/CapFrameX.View/AggregationView.xaml
@@ -46,7 +46,9 @@
 				   dragdrop:DragDrop.DefaultDragAdornerOpacity="0.5"
 				   dragdrop:DragDrop.UseDefaultEffectDataTemplate="False"/>
         <DataGrid Grid.Row="1" Grid.Column="1" x:Name="AggregationItemDataGrid" Height="275" Width="700" FontSize="11"
-				  MouseLeave="AggregationItemDataGrid_MouseLeave" SelectionMode="Single" VirtualizingStackPanel.VirtualizationMode="Standard"
+				  MouseLeave="AggregationItemDataGrid_MouseLeave" SelectionMode="Single"
+				  EnableRowVirtualization="True" EnableColumnVirtualization="True"
+				  VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling"
 				  SelectedIndex="{Binding SelectedAggregationEntryIndex}" ItemsSource="{Binding AggregationEntries}"
 				  CanUserSortColumns="False" CanUserAddRows="False" AutoGenerateColumns="False" PreviewKeyDown="AggregationItemDataGrid_PreviewKeyDown"
 				  materialDesign:DataGridAssist.CellPadding="13 8 8 8" materialDesign:DataGridAssist.ColumnHeaderPadding="8" IsSynchronizedWithCurrentItem="False"

--- a/source/CapFrameX.View/AggregationView.xaml
+++ b/source/CapFrameX.View/AggregationView.xaml
@@ -45,10 +45,11 @@
 				   dragdrop:DragDrop.UseDefaultDragAdorner="True"
 				   dragdrop:DragDrop.DefaultDragAdornerOpacity="0.5"
 				   dragdrop:DragDrop.UseDefaultEffectDataTemplate="False"/>
-        <DataGrid Grid.Row="1" Grid.Column="1" x:Name="AggregationItemDataGrid" Height="275" Width="700" FontSize="11"
+		<!-- Row backgrounds are assigned in code-behind; Standard mode prevents recycled rows retaining stale outlier colors. -->
+		<DataGrid Grid.Row="1" Grid.Column="1" x:Name="AggregationItemDataGrid" Height="275" Width="700" FontSize="11"
 				  MouseLeave="AggregationItemDataGrid_MouseLeave" SelectionMode="Single"
 				  EnableRowVirtualization="True" EnableColumnVirtualization="True"
-				  VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling"
+				  VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Standard"
 				  SelectedIndex="{Binding SelectedAggregationEntryIndex}" ItemsSource="{Binding AggregationEntries}"
 				  CanUserSortColumns="False" CanUserAddRows="False" AutoGenerateColumns="False" PreviewKeyDown="AggregationItemDataGrid_PreviewKeyDown"
 				  materialDesign:DataGridAssist.CellPadding="13 8 8 8" materialDesign:DataGridAssist.ColumnHeaderPadding="8" IsSynchronizedWithCurrentItem="False"

--- a/source/CapFrameX.View/ControlView.xaml
+++ b/source/CapFrameX.View/ControlView.xaml
@@ -194,8 +194,12 @@
 					        dragdrop:DragDrop.IsDropTarget="False"
 					        dragdrop:DragDrop.UseDefaultDragAdorner="True"
 					        dragdrop:DragDrop.DefaultDragAdornerOpacity="0.5"
-					        dragdrop:DragDrop.UseDefaultEffectDataTemplate="False"
+                            dragdrop:DragDrop.UseDefaultEffectDataTemplate="False"
                             Style="{StaticResource MaterialDesignDataGrid}"
+                            EnableRowVirtualization="True"
+                            EnableColumnVirtualization="True"
+                            VirtualizingPanel.IsVirtualizing="True"
+                            VirtualizingPanel.VirtualizationMode="Recycling"
                             Background="{DynamicResource MaterialDesignBackground}">
                         <DataGrid.Resources>
                             <Style TargetType="{x:Type DataGridRow}">

--- a/source/CapFrameX.ViewModel/ComparisonViewModel.cs
+++ b/source/CapFrameX.ViewModel/ComparisonViewModel.cs
@@ -30,6 +30,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reactive;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Windows;
 using System.Windows.Controls;
@@ -112,6 +113,7 @@ namespace CapFrameX.ViewModel
         private bool _isDistributionChartDirty = true;
         private bool _isFpsChartDirty = true;
         private bool _isFrametimeChartDirty = true;
+        private readonly ISubject<Unit> _rangeSliderUpdate = new Subject<Unit>();
 
         public Array FirstMetricItems => Enum.GetValues(typeof(EMetric))
             .Cast<EMetric>().Where(metric => metric != EMetric.None && metric != EMetric.GpuActiveAverage && metric != EMetric.GpuActiveOnePercentLowAverage && metric != EMetric.GpuActiveP1)
@@ -415,7 +417,7 @@ namespace CapFrameX.ViewModel
                 SetChartUpdateFlags();
 
                 if (ComparisonRangeSliderRealTime)
-                    UpdateCharts();
+                    _rangeSliderUpdate.OnNext(default);
             }
         }
 
@@ -432,7 +434,7 @@ namespace CapFrameX.ViewModel
                 SetChartUpdateFlags();
 
                 if (ComparisonRangeSliderRealTime)
-                    UpdateCharts();
+                    _rangeSliderUpdate.OnNext(default);
             }
         }
 
@@ -461,7 +463,7 @@ namespace CapFrameX.ViewModel
                 RaisePropertyChanged(nameof(IsVarianceChartTabActive));
                 RaisePropertyChanged(nameof(IsDistributionTabActive));
                 OnChartItemChanged();
-                UpdateCharts();
+                UpdateChartsSafely();
 
                 if (!IsLineChartTabActive && !IsDistributionTabActive)
                 {
@@ -633,7 +635,7 @@ namespace CapFrameX.ViewModel
                 else
                     ComparisonLShapeYAxisLabel = "FPS" + Environment.NewLine + " ";
                 RaisePropertyChanged();
-                UpdateCharts();
+                UpdateChartsSafely();
             }
         }
 
@@ -698,7 +700,7 @@ namespace CapFrameX.ViewModel
                 _isDistributionChartDirty = true;
                 RaisePropertyChanged();
                 InitializePlotModels();
-                UpdateCharts();
+                UpdateChartsSafely();
             }
         }
 
@@ -711,7 +713,7 @@ namespace CapFrameX.ViewModel
                 IsFpsChartDirty = true;
                 IsFrametimeChartDirty = true;
                 RaisePropertyChanged();
-                UpdateCharts();
+                UpdateChartsSafely();
             }
         }
 
@@ -869,6 +871,11 @@ namespace CapFrameX.ViewModel
             SubscribeToSelectRecord();
             SubscribeToUpdateRecordInfos();
             SubscribeToThemeChanged();
+            _rangeSliderUpdate
+                .Throttle(TimeSpan.FromMilliseconds(75))
+                .ObserveOnDispatcher()
+                .Subscribe(_ => UpdateChartsSafely(), error =>
+                    _logger?.LogError(error, "The comparison chart update pipeline stopped unexpectedly."));
 
             LineGraphColors = new ObservableCollection<ComparisonColorItems>(
                 _appConfiguration.ComparisonLineGraphColors
@@ -1311,6 +1318,20 @@ namespace CapFrameX.ViewModel
             RaisePropertyChanged(nameof(MetricAndLabelOptionsEnabled));
         }
 
+        private void UpdateChartsSafely()
+        {
+            try
+            {
+                UpdateCharts();
+            }
+            catch (Exception exception)
+            {
+                SetChartUpdateFlags();
+                _logger?.LogError(exception,
+                    "A comparison chart update failed. The next update will retry the complete redraw.");
+            }
+        }
+
         private void OnChartItemChanged()
         {
             if (SelectedChartItem?.Header.ToString().Contains("Line") ?? false)
@@ -1447,7 +1468,7 @@ namespace CapFrameX.ViewModel
         private void OnRangeSliderChanged()
         {
             UpdateRangeSliderParameter();
-            UpdateCharts();
+            UpdateChartsSafely();
         }
 
         public void OnRangeSliderValuesChanged()
@@ -1459,13 +1480,13 @@ namespace CapFrameX.ViewModel
                 LastSeconds = MaxRecordingTime;
 
             if (!ComparisonRangeSliderRealTime)
-                UpdateCharts();
+                UpdateChartsSafely();
         }
 
         public void OnRangeSliderDragCompleted()
         {
             if (!ComparisonRangeSliderRealTime)
-                UpdateCharts();
+                UpdateChartsSafely();
         }
 
         internal class ChartLabel
@@ -1579,74 +1600,15 @@ namespace CapFrameX.ViewModel
 
         private void UpdateAxesMinMaxFrametimeChart()
         {
-            if (ComparisonRecords == null || !ComparisonRecords.Any())
-                return;
-
             var xAxis = ComparisonFrametimesModel.GetAxisOrDefault("xAxis", null);
             var yAxis = ComparisonFrametimesModel.GetAxisOrDefault("yAxis", null);
 
-            if (xAxis == null || yAxis == null)
+            double xMin, xMax, yMin, yMax;
+            if (xAxis == null || yAxis == null
+                || !TryGetSeriesBounds(ComparisonFrametimesModel, out xMin, out xMax, out yMin, out yMax))
                 return;
 
             xAxis.Reset();
-
-            double xMin = 0;
-            double xMax = 0;
-            double yMin = 0;
-            double yMax = 0;
-
-            double startTime = FirstSeconds;
-            double endTime = LastSeconds;
-
-            var sessionParallelQuery = ComparisonRecords.Select(record => record.WrappedRecordInfo.Session).AsParallel();
-
-            xMin = sessionParallelQuery.Min(session =>
-            {
-                var window = session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                if (window.Any())
-                    return window.First().X;
-                else
-                    return double.MaxValue;
-            });
-
-            xMax = sessionParallelQuery.Max(session =>
-            {
-                var window = session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                if (window.Any())
-                    return window.Last().X;
-                else
-                    return double.MinValue;
-            });
-
-            yMin = sessionParallelQuery.Min(session =>
-            {
-                IList<Point> window = null;
-
-                if (ShowGpuActiveLineCharts)
-                    window = session.GetGpuActiveTimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                else
-                    window = session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.Min(pnt => pnt.Y);
-                else
-                    return double.MaxValue;
-            });
-
-            yMax = sessionParallelQuery.Max(session =>
-            {
-                IList<Point> window = null;
-
-                if (ShowGpuActiveLineCharts)
-                    window = session.GetGpuActiveTimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                else
-                    window = session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.Max(pnt => pnt.Y);
-                else
-                    return double.MinValue;
-            });
 
             xAxis.Minimum = xMin;
             xAxis.Maximum = xMax;
@@ -1657,79 +1619,17 @@ namespace CapFrameX.ViewModel
             ComparisonFrametimesModel.InvalidatePlot(true);
         }
 
-        // ToDo: Optimieren!
         private void UpdateAxesMinMaxFpsChart()
         {
-            if (ComparisonRecords == null || !ComparisonRecords.Any())
-                return;
-
             var xAxis = ComparisonFpsModel.GetAxisOrDefault("xAxis", null);
             var yAxis = ComparisonFpsModel.GetAxisOrDefault("yAxis", null);
 
-            if (xAxis == null || yAxis == null)
+            double xMin, xMax, yMin, yMax;
+            if (xAxis == null || yAxis == null
+                || !TryGetSeriesBounds(ComparisonFpsModel, out xMin, out xMax, out yMin, out yMax))
                 return;
 
             xAxis.Reset();
-
-            double xMin = 0;
-            double xMax = 0;
-            double yMin = 0;
-            double yMax = 0;
-
-            double startTime = FirstSeconds;
-            double endTime = LastSeconds;
-
-            var sessionParallelQuery = ComparisonRecords.Select(record => record.WrappedRecordInfo.Session).AsParallel();
-
-            xMin = sessionParallelQuery.Min(session =>
-            {
-                IList<Point> window = session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.First().X;
-                else
-                    return double.MaxValue;
-            });
-
-            xMax = sessionParallelQuery.Max(session =>
-            {
-                IList<Point> window = session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.Last().X;
-                else
-                    return double.MinValue;
-            });
-
-            yMin = sessionParallelQuery.Min(session =>
-            {
-                IList<Point> window = null;
-
-                //if (ShowGpuActiveLineCharts)
-                //	window = session.GetGpuActiveFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode);
-                //else
-                window = session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode);
-
-                if (window.Any())
-                    return window.Min(pnt => pnt.Y);
-                else
-                    return double.MaxValue;
-            });
-
-            yMax = sessionParallelQuery.Max(session =>
-            {
-                IList<Point> window = null;
-
-                //if (ShowGpuActiveLineCharts)
-                //	window = session.GetGpuActiveFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode);
-                //else
-                window = session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode);
-
-                if (window.Any())
-                    return window.Max(pnt => pnt.Y);
-                else
-                    return double.MinValue;
-            });
 
             xAxis.Minimum = xMin;
             xAxis.Maximum = xMax;
@@ -1742,69 +1642,15 @@ namespace CapFrameX.ViewModel
 
         private void UpdateAxesMinMaxDistributionChart()
         {
-
-            if (ComparisonRecords == null || !ComparisonRecords.Any())
-                return;
-
             var xAxis = ComparisonDistributionModel.GetAxisOrDefault("xAxis", null);
             var yAxis = ComparisonDistributionModel.GetAxisOrDefault("yAxis", null);
 
-            if (xAxis == null || yAxis == null)
+            double xMin, xMax, yMin, yMax;
+            if (xAxis == null || yAxis == null
+                || !TryGetSeriesBounds(ComparisonDistributionModel, out xMin, out xMax, out yMin, out yMax))
                 return;
 
-            double startTime = FirstSeconds;
-            double endTime = LastSeconds;
-
             xAxis.Reset();
-
-            double xMin = 0;
-            double xMax = 0;
-            double yMin = 0;
-            double yMax = 0;
-
-            var sessionParallelQuery = ComparisonRecords.Select(record => record.WrappedRecordInfo.Session).AsParallel();
-
-            xMin = sessionParallelQuery.Min(session =>
-            {
-                var window = session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                if (window.Any())
-                    return window.First().X;
-                else
-                    return double.MaxValue;
-            });
-
-            xMax = sessionParallelQuery.Max(session =>
-            {
-                var window = session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-                if (window.Any())
-                    return window.Last().X;
-                else
-                    return double.MinValue;
-            });
-
-            yMin = sessionParallelQuery.Min(session =>
-            {
-                IList<Point> window = null;
-
-                window = session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.Min(pnt => pnt.Y);
-                else
-                    return double.MaxValue;
-            });
-
-            yMax = sessionParallelQuery.Max(session =>
-            {
-                IList<Point> window = null;
-
-                window = session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-
-                if (window.Any())
-                    return window.Max(pnt => pnt.Y);
-                else
-                    return double.MinValue;
-            });
 
             xAxis.Minimum = xMin - 1;
             xAxis.Maximum = xMax;
@@ -1828,6 +1674,36 @@ namespace CapFrameX.ViewModel
 
 
             ComparisonDistributionModel.InvalidatePlot(true);
+        }
+
+        private static bool TryGetSeriesBounds(PlotModel plotModel, out double xMin, out double xMax,
+            out double yMin, out double yMax)
+        {
+            xMin = double.MaxValue;
+            xMax = double.MinValue;
+            yMin = double.MaxValue;
+            yMax = double.MinValue;
+            bool hasPoints = false;
+
+            foreach (var series in plotModel.Series.OfType<OxyPlot.Series.LineSeries>())
+            {
+                foreach (var point in series.Points)
+                {
+                    if (double.IsNaN(point.X) || double.IsInfinity(point.X)
+                        || double.IsNaN(point.Y) || double.IsInfinity(point.Y))
+                    {
+                        continue;
+                    }
+
+                    hasPoints = true;
+                    xMin = Math.Min(xMin, point.X);
+                    xMax = Math.Max(xMax, point.X);
+                    yMin = Math.Min(yMin, point.Y);
+                    yMax = Math.Max(yMax, point.Y);
+                }
+            }
+
+            return hasPoints;
         }
 
         private void UpdateBarChartHeight()
@@ -2326,7 +2202,7 @@ namespace CapFrameX.ViewModel
                 .Subscribe(msg =>
                 {
                     InitializePlotModels();
-                    UpdateCharts();
+                    UpdateChartsSafely();
                 });
         }
 

--- a/source/CapFrameX.ViewModel/ControlViewModel.cs
+++ b/source/CapFrameX.ViewModel/ControlViewModel.cs
@@ -24,6 +24,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Input;
 
 namespace CapFrameX.ViewModel
@@ -59,6 +60,10 @@ namespace CapFrameX.ViewModel
         private bool _customRamDescriptionChanged = false;
         private bool _customGameNameChanged = false;
         private bool _customCommentChanged = false;
+        private readonly SemaphoreSlim _selectionLoadSemaphore = new SemaphoreSlim(1, 1);
+        private Task<ISession> _selectedSessionTask = Task.FromResult<ISession>(null);
+        private CancellationTokenSource _selectionLoadCancellation = new CancellationTokenSource();
+        private int _selectionVersion;
 
         public bool ShowCreationDate
         {
@@ -124,6 +129,8 @@ namespace CapFrameX.ViewModel
             get { return _selectedRecordInfo; }
             set
             {
+                if (ReferenceEquals(_selectedRecordInfo, value))
+                    return;
 
                 _selectedRecordInfo = value;
                 OnSelectedRecordInfoChanged();
@@ -769,40 +776,107 @@ namespace CapFrameX.ViewModel
             }
         }
 
-        public void OnRecordSelectByDoubleClick()
+        public async void OnRecordSelectByDoubleClick()
         {
-            if (SelectedRecordInfo != null && _selectSessionEvent != null)
+            var selectedRecordInfo = SelectedRecordInfo;
+            if (selectedRecordInfo != null && _selectSessionEvent != null)
             {
-                var session = _recordManager.LoadData(SelectedRecordInfo.FullPath);
-                _selectSessionEvent.Publish(new ViewMessages.SelectSession(session, SelectedRecordInfo));
+                try
+                {
+                    // Reuse the selection load and retain UpdateSession-before-SelectSession ordering.
+                    var session = await _selectedSessionTask;
+                    if (session != null && ReferenceEquals(_selectedRecordInfo, selectedRecordInfo))
+                    {
+                        _selectSessionEvent.Publish(new ViewMessages.SelectSession(session, selectedRecordInfo));
+                    }
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogError(exception, "Error selecting record {RecordPath}.", selectedRecordInfo.FullPath);
+                }
             }
         }
 
         private void OnSelectedRecordInfoChanged()
         {
-            if (_selectedRecordInfo is null)
+            int selectionVersion = Interlocked.Increment(ref _selectionVersion);
+            var newCancellation = new CancellationTokenSource();
+            var previousCancellation = Interlocked.Exchange(ref _selectionLoadCancellation, newCancellation);
+            previousCancellation?.Cancel();
+            previousCancellation?.Dispose();
+            var selectedRecordInfo = _selectedRecordInfo;
+
+            if (selectedRecordInfo is null)
             {
+                _selectedSessionTask = Task.FromResult<ISession>(null);
                 ResetInfoEditBoxes();
+                ResetDescriptionChangedFlags();
             }
             else
             {
-                var session = _recordManager.LoadData(_selectedRecordInfo.FullPath);
-                if (session is ISession)
+                // FileRecordInfo already contains these fields, so the editor can update without
+                // waiting for the complete capture to be parsed on the background thread.
+                CustomCpuDescription = string.Copy(selectedRecordInfo.ProcessorName ?? string.Empty);
+                CustomGpuDescription = string.Copy(selectedRecordInfo.GraphicCardName ?? string.Empty);
+                CustomRamDescription = string.Copy(selectedRecordInfo.SystemRamInfo ?? string.Empty);
+                CustomGameName = string.Copy(selectedRecordInfo.GameName ?? string.Empty);
+                CustomComment = string.Copy(selectedRecordInfo.Comment ?? string.Empty);
+                ResetDescriptionChangedFlags();
+                _selectedSessionTask = LoadSelectedSessionAsync(selectedRecordInfo, selectionVersion,
+                    newCancellation.Token);
+            }
+        }
+
+        private async Task<ISession> LoadSelectedSessionAsync(IFileRecordInfo selectedRecordInfo,
+            int selectionVersion, CancellationToken cancellationToken)
+        {
+            bool lockTaken = false;
+            try
+            {
+                await _selectionLoadSemaphore.WaitAsync(cancellationToken);
+                lockTaken = true;
+
+                // Rapid navigation can queue several records behind an active HDD read. Only the
+                // newest queued selection is allowed to start another read.
+                if (cancellationToken.IsCancellationRequested
+                    || !IsCurrentSelection(selectedRecordInfo, selectionVersion))
+                {
+                    return null;
+                }
+
+                var session = await Task.Run(
+                    () => _recordManager.LoadData(selectedRecordInfo.FullPath), cancellationToken);
+                if (session != null && !cancellationToken.IsCancellationRequested
+                    && IsCurrentSelection(selectedRecordInfo, selectionVersion))
                 {
                     if (_updateSessionEvent != null)
                     {
-                        _updateSessionEvent.Publish(new ViewMessages.UpdateSession(session, SelectedRecordInfo));
+                        _updateSessionEvent.Publish(new ViewMessages.UpdateSession(session, selectedRecordInfo));
                     }
-                    CustomCpuDescription = string.Copy(SelectedRecordInfo.ProcessorName ?? string.Empty);
-                    CustomGpuDescription = string.Copy(SelectedRecordInfo.GraphicCardName ?? string.Empty);
-                    CustomRamDescription = string.Copy(SelectedRecordInfo.SystemRamInfo ?? string.Empty);
-                    CustomGameName = string.Copy(SelectedRecordInfo.GameName ?? string.Empty);
-                    CustomComment = string.Copy(SelectedRecordInfo.Comment ?? string.Empty);
+                    return session;
                 }
-            }
 
-            ResetDescriptionChangedFlags();
+                return null;
+            }
+            catch (OperationCanceledException)
+            {
+                return null;
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(exception, "Error loading selected record {RecordPath}.", selectedRecordInfo.FullPath);
+                return null;
+            }
+            finally
+            {
+                if (lockTaken)
+                    _selectionLoadSemaphore.Release();
+            }
         }
+
+        private bool IsCurrentSelection(IFileRecordInfo selectedRecordInfo, int selectionVersion)
+            => Volatile.Read(ref _selectionVersion) == selectionVersion
+                && ReferenceEquals(_selectedRecordInfo, selectedRecordInfo);
 
         private void OnPressDeleteKey()
             => OnDeleteRecordFile();


### PR DESCRIPTION
## Summary

This extracts the baseline-compatible legacy WPF/OxyPlot responsiveness work from #398, following the review request.

It deliberately avoids statistics algorithms, timing-source behavior, record parsing, persistence, and build tooling so the 1.x UI work can be reviewed independently.

## Plot rendering

- Decimate dense OxyPlot lines in screen space while preserving raw source points.
- Preserve first/last points, per-column minima/maxima, ordering, and non-finite gaps.
- Keep tracker, zoom, and export behavior on full-resolution data.
- Batch plot invalidation so each refresh is rendered once.
- Represent constant average/threshold lines with two endpoints instead of one point per frame.

## WPF and selection responsiveness

- Keep recycling virtualization on the main record grid.
- Keep row/column virtualization on the aggregation grid, but use Standard mode because its outlier background is assigned directly to row containers; Recycling could retain stale colors after scrolling.
- Load selected captures outside the UI thread.
- Serialize loads, cancel obsolete requests, and prevent stale publication.
- Reuse the selected session for double-click navigation and observe/log background faults.
- Debounce rapid comparison-slider redraws.
- Derive comparison bounds from already-rendered finite series points instead of analyzing sessions twice.

## Deliberately excluded

- Statistics correctness/performance and timing-source changes.
- Record parsing, caching, and persistent indexing.
- DataViewModel/threshold/synchronization work requiring new statistics APIs.
- Aggregation session/array retention.
- Build tooling and dependencies.

## Validation

- x64 Release application build: passed, 0 errors.
- x64 Release test build: passed, 0 errors.
- Focused UI/rendering tests: 7/7 passed.
- Full suite: 261 total, 256 passed, 5 hardware-dependent skips, 0 failed.
- `git diff --check`: passed.
- No package/dependency changes.

The five commits remain separated into rendering, virtualization, selection loading, comparison redraw, and the reviewed aggregation-highlight fix.

This PR is based directly on `v1.8.6` (`383bc029`).
