### PR TITLE
Fix timing statistics correctness and source consistency

### DIFF
--- a/source/CapFrameX.PresentMonInterface/OnlineMetricService.cs
+++ b/source/CapFrameX.PresentMonInterface/OnlineMetricService.cs
@@ -66,6 +66,9 @@ namespace CapFrameX.PresentMonInterface
         // Reusable list buffers to avoid allocations during metric calculations
         private List<double> _reusableListBufferA;
         private List<double> _reusableListBufferB;
+        // The five-second path is protected by a different lock and therefore
+        // must not share the realtime path's mutable scratch buffer.
+        private List<double> _reusableListBuffer5Seconds;
 
         // Disposable resources
         private IDisposable _frameDataSubscription;
@@ -101,6 +104,7 @@ namespace CapFrameX.PresentMonInterface
             // Initialize reusable buffers
             _reusableListBufferA = new List<double>(LIST_CAPACITY);
             _reusableListBufferB = new List<double>(LIST_CAPACITY);
+            _reusableListBuffer5Seconds = new List<double>(LIST_CAPACITY);
 
             SubscribeToUpdateSession();
             ConnectOnlineMetricDataStream();
@@ -441,14 +445,19 @@ namespace CapFrameX.PresentMonInterface
             lock (_lockRealtimeMetric)
             {
                 // Use frame times when calculating average fps
-                var buffer = (_appConfiguration.UseDisplayChangeMetrics && metric != EMetric.Average)
+                var useDisplayTimes = _appConfiguration.UseDisplayChangeMetrics && metric != EMetric.Average;
+                var buffer = useDisplayTimes
                     ? _displayedtimesRealtimeSeconds : _frametimesRealtimeSeconds;
 
                 if (buffer == null || buffer.Count == 0)
                     return double.NaN;
 
-                // Reuse list buffer to avoid allocations
-                var samples = buffer.ToList(_reusableListBufferA);
+                var samples = CopyValidTimings(buffer, _reusableListBufferA);
+                if (samples.Count == 0 && useDisplayTimes)
+                    samples = CopyValidTimings(_frametimesRealtimeSeconds, _reusableListBufferA);
+
+                if (samples.Count == 0)
+                    return double.NaN;
 
                 return _frametimeStatisticProvider
                     .GetFpsMetricValue(samples, metric);
@@ -521,23 +530,37 @@ namespace CapFrameX.PresentMonInterface
         {
             lock (_lock5SecondsMetric)
             {
-                var buffer = _appConfiguration.UseDisplayChangeMetrics ? _displaytimes5Seconds : _frametimes5Seconds;
+                var useDisplayTimes = _appConfiguration.UseDisplayChangeMetrics;
+                var buffer = useDisplayTimes ? _displaytimes5Seconds : _frametimes5Seconds;
 
                 if (buffer == null || buffer.Count == 0)
                     return double.NaN;
 
-                // Check for NaN values
-                foreach (var sample in buffer)
-                {
-                    if (double.IsNaN(sample))
-                        return double.NaN;
-                }
+                var samples = CopyValidTimings(buffer, _reusableListBuffer5Seconds);
+                if (samples.Count == 0 && useDisplayTimes)
+                    samples = CopyValidTimings(_frametimes5Seconds, _reusableListBuffer5Seconds);
 
-                var samples = buffer.ToList(_reusableListBufferA);
+                if (samples.Count == 0)
+                    return double.NaN;
 
                 return _frametimeStatisticProvider
                     .GetOnlineStutteringTimePercentage(samples, _appConfiguration.StutteringFactor);
             }
+        }
+
+        private static List<double> CopyValidTimings(IEnumerable<double> source, List<double> target)
+        {
+            target.Clear();
+            if (source == null)
+                return target;
+
+            foreach (double timing in source)
+            {
+                if (timing > 0 && !double.IsNaN(timing) && !double.IsInfinity(timing))
+                    target.Add(timing);
+            }
+
+            return target;
         }
 
         public double GetOnlinePcLatencyAverageValue()
@@ -716,6 +739,7 @@ namespace CapFrameX.PresentMonInterface
 
                 _reusableListBufferA?.Clear();
                 _reusableListBufferB?.Clear();
+                _reusableListBuffer5Seconds?.Clear();
             }
 
             _disposed = true;

--- a/source/CapFrameX.PresentMonInterface/OnlineMetricService.cs
+++ b/source/CapFrameX.PresentMonInterface/OnlineMetricService.cs
@@ -710,6 +710,8 @@ namespace CapFrameX.PresentMonInterface
                     _gpuActiveTimesRealtimeSeconds?.Clear();
                     _cpuActiveTimesRealtimeSeconds?.Clear();
                     _measuretimesRealtimeSeconds?.Clear();
+                    _reusableListBufferA?.Clear();
+                    _reusableListBufferB?.Clear();
                 }
 
                 lock (_lock5SecondsMetric)
@@ -717,6 +719,7 @@ namespace CapFrameX.PresentMonInterface
                     _frametimes5Seconds?.Clear();
                     _displaytimes5Seconds?.Clear();
                     _measuretimes5Seconds?.Clear();
+                    _reusableListBuffer5Seconds?.Clear();
                 }
 
                 lock (_lock1SecondMetric)
@@ -736,10 +739,6 @@ namespace CapFrameX.PresentMonInterface
                     _channelDataBuffer?.Clear();
                     _sensorDataBuffer?.Clear();
                 }
-
-                _reusableListBufferA?.Clear();
-                _reusableListBufferB?.Clear();
-                _reusableListBuffer5Seconds?.Clear();
             }
 
             _disposed = true;

--- a/source/CapFrameX.Statistics.NetStandard/Contracts/IStatisticProvider.cs
+++ b/source/CapFrameX.Statistics.NetStandard/Contracts/IStatisticProvider.cs
@@ -39,6 +39,8 @@ namespace CapFrameX.Statistics.NetStandard.Contracts
 
         IList<double> GetFpsThresholdTimes(IList<double> frametimes, bool isReversed);
 
+        IList<double> GetVariancePercentages(IList<double> sequence);
+
         IList<double> GetFrametimeVariancePercentages(ISession session);
 
         IList<double> GetDisplayTimeVariancePercentages(ISession session);

--- a/source/CapFrameX.Statistics.NetStandard/Contracts/IStatisticProvider.cs
+++ b/source/CapFrameX.Statistics.NetStandard/Contracts/IStatisticProvider.cs
@@ -41,6 +41,8 @@ namespace CapFrameX.Statistics.NetStandard.Contracts
 
         IList<double> GetVariancePercentages(IList<double> sequence);
 
+        IList<double> GetVariancePercentages(IEnumerable<IList<double>> sequences);
+
         IList<double> GetFrametimeVariancePercentages(ISession session);
 
         IList<double> GetDisplayTimeVariancePercentages(ISession session);

--- a/source/CapFrameX.Statistics.NetStandard/FrametimeStatisticProvider.cs
+++ b/source/CapFrameX.Statistics.NetStandard/FrametimeStatisticProvider.cs
@@ -138,21 +138,49 @@ namespace CapFrameX.Statistics.NetStandard
             {
                 case ERemoveOutlierMethod.DeciPercentile:
                     {
-                        var deciPercentile = sequence.Quantile(TAU);
-                        adjustedSequence = new List<double>();
-
-                        foreach (var element in sequence)
+                        if (sequence.Count < 2 || sequence.All(value => value == sequence[0]))
                         {
-                            if (element < deciPercentile)
+                            adjustedSequence = new List<double>(sequence);
+                            break;
+                        }
+
+                        // Remove exactly the slowest 0.1% while preserving capture order.
+                        // Subtracting the epsilon avoids removing two values for 1000 samples
+                        // because 1000 * (1 - 0.999) is slightly greater than one in binary.
+                        int removeCount = Math.Max(1,
+                            (int)Math.Ceiling(sequence.Count * (1 - TAU) - 1E-9));
+                        var sortedValues = sequence.ToArray();
+                        Array.Sort(sortedValues);
+                        var removals = new Dictionary<double, int>();
+
+                        for (int i = sortedValues.Length - removeCount; i < sortedValues.Length; i++)
+                        {
+                            int count;
+                            removals.TryGetValue(sortedValues[i], out count);
+                            removals[sortedValues[i]] = count + 1;
+                        }
+
+                        adjustedSequence = new List<double>(sequence.Count - removeCount);
+                        foreach (double element in sequence)
+                        {
+                            int count;
+                            if (removals.TryGetValue(element, out count) && count > 0)
+                            {
+                                removals[element] = count - 1;
+                            }
+                            else
+                            {
                                 adjustedSequence.Add(element);
+                            }
                         }
                     }
                     break;
                 case ERemoveOutlierMethod.InterquartileRange:
-                    break;
                 case ERemoveOutlierMethod.ThreeSigma:
-                    break;
                 case ERemoveOutlierMethod.TwoDotFiveSigma:
+                    // These modes are not implemented. Returning the source is safer than
+                    // returning null to callers which expect a sequence.
+                    adjustedSequence = sequence;
                     break;
                 case ERemoveOutlierMethod.None:
                     adjustedSequence = sequence;
@@ -699,100 +727,66 @@ namespace CapFrameX.Statistics.NetStandard
         public IList<double> GetFrametimeVariancePercentages(ISession session)
         {
             if (!session.Runs.Any())
-                return new List<double>();
+                return new double[5];
 
-            // Create bins for variance thresholds
-            int threshold2Count = 0;
-            int threshold4Count = 0;
-            int threshold8Count = 0;
-            int threshold12Count = 0;
-            int thresholdOver12Count = 0;
-
-            // Get frametime variances
-            double varianceCount = 0.0;
-            foreach (var run in session.Runs)
-            {
-                var frametimes = run.CaptureData.MsBetweenPresents.ToArray();
-                for (int i = 1; i < frametimes.Count(); i++)
-                {
-                    double variance = Math.Abs(frametimes[i] - frametimes[i - 1]);
-
-                    if (variance < 2)
-                        threshold2Count++;
-                    else if (variance < 4)
-                        threshold4Count++;
-                    else if (variance < 8)
-                        threshold8Count++;
-                    else if (variance < 12)
-                        threshold12Count++;
-                    else
-                        thresholdOver12Count++;
-
-                    varianceCount++;
-                }
-            }
-
-
-            // Add percentage of variance bins to List
-            IList<double> variancePercentages = new List<double>
-            {
-                Math.Round(threshold2Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold4Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold8Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold12Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(thresholdOver12Count / varianceCount, 4, MidpointRounding.AwayFromZero)
-            };
-
-            return variancePercentages;
+            return GetVariancePercentages(session.Runs
+                .Select(run => (IList<double>)run.CaptureData.MsBetweenPresents));
         }
 
         public IList<double> GetDisplayTimeVariancePercentages(ISession session)
         {
             if (!session.Runs.Any())
-                return new List<double>();
+                return new double[5];
 
-            // Create bins for variance thresholds
-            int threshold2Count = 0;
-            int threshold4Count = 0;
-            int threshold8Count = 0;
-            int threshold12Count = 0;
-            int thresholdOver12Count = 0;
+            return GetVariancePercentages(session.Runs
+                .Select(run => (IList<double>)run.CaptureData.MsBetweenDisplayChange));
+        }
 
-            // Get frametime variances
-            double varianceCount = 0.0;
-            foreach (var run in session.Runs)
+        public IList<double> GetVariancePercentages(IList<double> sequence)
+        {
+            return GetVariancePercentages(new[] { sequence });
+        }
+
+        private static IList<double> GetVariancePercentages(IEnumerable<IList<double>> sequences)
+        {
+            var thresholds = new int[5];
+            var varianceCount = 0;
+
+            foreach (var sequence in sequences.Where(candidate => candidate != null))
             {
-                var displayTimes = run.CaptureData.MsBetweenDisplayChange.ToArray();
-                for (int i = 1; i < displayTimes.Count(); i++)
+                for (int i = 1; i < sequence.Count; i++)
                 {
-                    double variance = Math.Abs(displayTimes[i] - displayTimes[i - 1]);
+                    double previous = sequence[i - 1];
+                    double current = sequence[i];
+                    if (double.IsNaN(previous) || double.IsInfinity(previous)
+                        || double.IsNaN(current) || double.IsInfinity(current))
+                    {
+                        continue;
+                    }
 
+                    double variance = Math.Abs(current - previous);
                     if (variance < 2)
-                        threshold2Count++;
+                        thresholds[0]++;
                     else if (variance < 4)
-                        threshold4Count++;
+                        thresholds[1]++;
                     else if (variance < 8)
-                        threshold8Count++;
+                        thresholds[2]++;
                     else if (variance < 12)
-                        threshold12Count++;
+                        thresholds[3]++;
                     else
-                        thresholdOver12Count++;
+                        thresholds[4]++;
 
                     varianceCount++;
                 }
             }
 
-            // Add percentage of variance bins to List
-            IList<double> variancePercentages = new List<double>
-            {
-                Math.Round(threshold2Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold4Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold8Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(threshold12Count / varianceCount, 4, MidpointRounding.AwayFromZero),
-                Math.Round(thresholdOver12Count / varianceCount, 4, MidpointRounding.AwayFromZero)
-            };
+            if (varianceCount == 0)
+                return new double[5];
 
-            return variancePercentages;
+            return thresholds
+                .Select(count => Math.Round((double)count / varianceCount, 4,
+                    MidpointRounding.AwayFromZero))
+                .ToList();
         }
     }
 }

--- a/source/CapFrameX.Statistics.NetStandard/FrametimeStatisticProvider.cs
+++ b/source/CapFrameX.Statistics.NetStandard/FrametimeStatisticProvider.cs
@@ -747,7 +747,7 @@ namespace CapFrameX.Statistics.NetStandard
             return GetVariancePercentages(new[] { sequence });
         }
 
-        private static IList<double> GetVariancePercentages(IEnumerable<IList<double>> sequences)
+        public IList<double> GetVariancePercentages(IEnumerable<IList<double>> sequences)
         {
             var thresholds = new int[5];
             var varianceCount = 0;

--- a/source/CapFrameX.Statistics.NetStandard/SessionExtensions.cs
+++ b/source/CapFrameX.Statistics.NetStandard/SessionExtensions.cs
@@ -9,31 +9,87 @@ namespace CapFrameX.Statistics.NetStandard
 {
     public static class SessionExtensions
     {
-		private static IList<double> FilterDataWithinTimeWindow(IList<double> startTimes, IList<double> data, double startTime, double endTime)
+		private static IList<double> FilterDataWithinTimeWindow(IList<double> startTimes, IList<double> data,
+            double startTime, double endTime, FrametimeStatisticProvider statisticProvider = null,
+            ERemoveOutlierMethod removeOutlierMethod = ERemoveOutlierMethod.None,
+            Func<double, bool> isValidValue = null)
 		{
-			return startTimes.Zip(data, (t, y) => new { t, y })
-					 .Where(pair => pair.t >= startTime && pair.t <= endTime)
-					 .Select(pair => pair.y)
-					 .ToList();
+            int count = Math.Min(startTimes.Count, data.Count);
+            var filteredData = new List<double>(count);
+            var valueValidator = isValidValue ?? IsValidTimingValue;
+
+            for (int i = 0; i < count; i++)
+            {
+                double time = startTimes[i];
+                double value = data[i];
+                if (time >= startTime && time <= endTime && valueValidator(value))
+                    filteredData.Add(value);
+            }
+
+            return statisticProvider == null
+                ? filteredData
+                : statisticProvider.GetOutlierAdjustedSequence(filteredData, removeOutlierMethod);
 		}
 
-		private static IList<Point> FilterDataPointsWithinTimeWindow(IList<double> startTimes, IList<double> data, double startTime, double endTime)
+		private static IList<Point> FilterDataPointsWithinTimeWindow(IList<double> startTimes, IList<double> data,
+            double startTime, double endTime, FrametimeStatisticProvider statisticProvider = null,
+            ERemoveOutlierMethod removeOutlierMethod = ERemoveOutlierMethod.None,
+            Func<double, bool> isValidValue = null)
 		{
-			return startTimes.Zip(data, (t, y) => new Point(t, y))
-					 .Where(point => point.X >= startTime && point.X <= endTime)
-					 .ToList();
+            int count = Math.Min(startTimes.Count, data.Count);
+            var filteredPoints = new List<Point>(count);
+            var valueValidator = isValidValue ?? IsValidTimingValue;
+
+            for (int i = 0; i < count; i++)
+            {
+                double time = startTimes[i];
+                double value = data[i];
+                if (time >= startTime && time <= endTime && valueValidator(value))
+                    filteredPoints.Add(new Point(time, value));
+            }
+
+            if (removeOutlierMethod == ERemoveOutlierMethod.None || filteredPoints.Count == 0)
+                return filteredPoints;
+
+            var adjustedValues = statisticProvider.GetOutlierAdjustedSequence(
+                filteredPoints.Select(point => point.Y).ToArray(), removeOutlierMethod);
+            var remainingValueCounts = adjustedValues
+                .GroupBy(value => value)
+                .ToDictionary(group => group.Key, group => group.Count());
+            var adjustedPoints = new List<Point>(adjustedValues.Count);
+
+            foreach (Point point in filteredPoints)
+            {
+                int remainingCount;
+                if (remainingValueCounts.TryGetValue(point.Y, out remainingCount) && remainingCount > 0)
+                {
+                    adjustedPoints.Add(point);
+                    remainingValueCounts[point.Y] = remainingCount - 1;
+                }
+            }
+
+            return adjustedPoints;
 		}
+
+        private static bool IsValidTimingValue(double value)
+        {
+            return value > 0 && !double.IsNaN(value) && !double.IsInfinity(value);
+        }
+
+        private static bool IsValidActiveTimeValue(double value)
+        {
+            return value >= 0 && !double.IsNaN(value) && !double.IsInfinity(value);
+        }
 
 		public static IList<double> GetFrametimeTimeWindow(this ISession session, double startTime, double endTime,
             IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
         {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
             var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var frametimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
+            var frametimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToArray();
 
-            return FilterDataWithinTimeWindow(frameStartTimes, frametimes, startTime, endTime);
+            return FilterDataWithinTimeWindow(frameStartTimes, frametimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod);
         }
 
         public static IList<double> GetDisplayChangeTimeWindow(this ISession session, double startTime, double endTime,
@@ -41,11 +97,10 @@ namespace CapFrameX.Statistics.NetStandard
         {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
             var dispalyStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var displayChangeTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
+            var displayChangeTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToArray();
 
-            return FilterDataWithinTimeWindow(dispalyStartTimes, displayChangeTimes, startTime, endTime);
+            return FilterDataWithinTimeWindow(dispalyStartTimes, displayChangeTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod);
         }
 
         public static IList<double> GetGpuActiveTimeTimeWindow(this ISession session, double startTime, double endTime,
@@ -53,12 +108,10 @@ namespace CapFrameX.Statistics.NetStandard
 		{
 			var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
 			var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
+            var gpuActiveTimes = session.Runs.SelectMany(r => r.CaptureData.GpuActive).ToArray();
 
-            var gpuActiveTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.GpuActive).ToArray(), eRemoveOutlierMethod)
-				?? Enumerable.Empty<double>().ToList();
-
-			return FilterDataWithinTimeWindow(frameStartTimes, gpuActiveTimes, startTime, endTime);
+			return FilterDataWithinTimeWindow(frameStartTimes, gpuActiveTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod, IsValidActiveTimeValue);
 		}
 
         public static IList<double> GetCpuActiveTimeTimeWindow(this ISession session, double startTime, double endTime,
@@ -67,11 +120,10 @@ namespace CapFrameX.Statistics.NetStandard
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
             var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
 
-            var cpuActiveTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.CpuActive).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
+            var cpuActiveTimes = session.Runs.SelectMany(r => r.CaptureData.CpuActive).ToArray();
 
-            return FilterDataWithinTimeWindow(frameStartTimes, cpuActiveTimes, startTime, endTime);
+            return FilterDataWithinTimeWindow(frameStartTimes, cpuActiveTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod, IsValidActiveTimeValue);
         }
 
         public static IList<double> GetAnimationErrorTimeWindow(this ISession session, double startTime, double endTime)
@@ -80,7 +132,8 @@ namespace CapFrameX.Statistics.NetStandard
             var animationErrors = session.Runs.SelectMany(r => r.CaptureData.AnimationError).ToArray();
 
             return frameStartTimes.Zip(animationErrors, (t, y) => new { t, y })
-                .Where(pair => pair.t >= startTime && pair.t <= endTime && !double.IsNaN(pair.y))
+                .Where(pair => pair.t >= startTime && pair.t <= endTime
+                    && !double.IsNaN(pair.y) && !double.IsInfinity(pair.y))
                 .Select(pair => pair.y)
                 .ToList();
         }
@@ -90,11 +143,10 @@ namespace CapFrameX.Statistics.NetStandard
         {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
 			var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-			var frametimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToArray(), eRemoveOutlierMethod)
-				?? Enumerable.Empty<double>().ToList();
+			var frametimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToArray();
 
-			return FilterDataPointsWithinTimeWindow(frameStartTimes, frametimes, startTime, endTime);
+			return FilterDataPointsWithinTimeWindow(frameStartTimes, frametimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod);
         }
 
         public static IList<Point> GetDisplayChangeTimePointsTimeWindow(this ISession session, double startTime, double endTime,
@@ -102,11 +154,10 @@ namespace CapFrameX.Statistics.NetStandard
         {
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
             var displayStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var displayChangeTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
+            var displayChangeTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToArray();
 
-            return FilterDataPointsWithinTimeWindow(displayStartTimes, displayChangeTimes, startTime, endTime);
+            return FilterDataPointsWithinTimeWindow(displayStartTimes, displayChangeTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod);
         }
 
         public static IList<Point> GetGpuActiveTimePointsTimeWindow(this ISession session, double startTime, double endTime,
@@ -114,12 +165,10 @@ namespace CapFrameX.Statistics.NetStandard
 		{
 			var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
 			var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
+			var gpuActiveTimes = session.Runs.SelectMany(r => r.CaptureData.GpuActive).ToArray();
 
-			var gpuActiveTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.GpuActive).ToArray(), eRemoveOutlierMethod)
-				?? Enumerable.Empty<double>().ToList();
-
-			return FilterDataPointsWithinTimeWindow(frameStartTimes, gpuActiveTimes, startTime, endTime);
+			return FilterDataPointsWithinTimeWindow(frameStartTimes, gpuActiveTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod, IsValidActiveTimeValue);
 		}
 
         public static IList<Point> GetCpuActiveTimePointsTimeWindow(this ISession session, double startTime, double endTime,
@@ -128,11 +177,10 @@ namespace CapFrameX.Statistics.NetStandard
             var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
             var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
 
-            var cpuActiveTimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.CpuActive).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
+            var cpuActiveTimes = session.Runs.SelectMany(r => r.CaptureData.CpuActive).ToArray();
 
-            return FilterDataPointsWithinTimeWindow(frameStartTimes, cpuActiveTimes, startTime, endTime);
+            return FilterDataPointsWithinTimeWindow(frameStartTimes, cpuActiveTimes, startTime, endTime,
+                frametimeStatisticProvider, eRemoveOutlierMethod, IsValidActiveTimeValue);
         }
 
 		public static IList<Point> GetFrametimePoints(this ISession session)
@@ -619,17 +667,36 @@ namespace CapFrameX.Statistics.NetStandard
         public static IList<Point> GetFrametimeDistributionPoints(this ISession session, double startTime, double endTime,
             IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
         {
-
-            var frametimeStatisticProvider = new FrametimeStatisticProvider(options);
             var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
-            var frametimes = frametimeStatisticProvider?
-                .GetOutlierAdjustedSequence(session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToArray(), eRemoveOutlierMethod)
-                ?? Enumerable.Empty<double>().ToList();
+            var frametimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToArray();
 
-            var filteredFrameTimes = FilterDataWithinTimeWindow(frameStartTimes, frametimes, startTime, endTime);
+            return GetTimingDistributionPoints(frameStartTimes, frametimes, startTime, endTime,
+                options, eRemoveOutlierMethod);
+        }
+
+        public static IList<Point> GetDisplayTimeDistributionPoints(this ISession session, double startTime, double endTime,
+            IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod = ERemoveOutlierMethod.None)
+        {
+            var frameStartTimes = session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).ToArray();
+            var displayTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToArray();
+
+            return GetTimingDistributionPoints(frameStartTimes, displayTimes, startTime, endTime,
+                options, eRemoveOutlierMethod);
+        }
+
+        private static IList<Point> GetTimingDistributionPoints(IList<double> frameStartTimes,
+            IList<double> timingValues, double startTime, double endTime,
+            IFrametimeStatisticProviderOptions options, ERemoveOutlierMethod eRemoveOutlierMethod)
+        {
+            var statisticProvider = new FrametimeStatisticProvider(options);
+            var filteredFrameTimes = FilterDataWithinTimeWindow(frameStartTimes, timingValues,
+                startTime, endTime, statisticProvider, eRemoveOutlierMethod);
+
+            if (filteredFrameTimes.Count == 0)
+                return new List<Point>();
 
             // Bin increments
-            double increments = 0.1;
+            const double increments = 0.1;
             double maxValue = filteredFrameTimes.Max();
 
 

--- a/source/CapFrameX.Test/CapFrameX.Test.csproj
+++ b/source/CapFrameX.Test/CapFrameX.Test.csproj
@@ -101,6 +101,8 @@
     <Compile Include="TestHelper.cs" />
     <Compile Include="Updater\UpdateCheckTest.cs" />
     <Compile Include="ViewModel\CaptureViewModelTest.cs" />
+    <Compile Include="ViewModel\ComparisonMetricSourceResolverTest.cs" />
+    <Compile Include="ViewModel\FpsGraphDataContextTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestRecordFiles\CustomFilenameWithoutComment.csv">

--- a/source/CapFrameX.Test/CapFrameX.Test.csproj
+++ b/source/CapFrameX.Test/CapFrameX.Test.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Sensor\PantherLakeVoltageTest.cs" />
     <Compile Include="Statistics\CircularBufferTest.cs" />
     <Compile Include="Statistics\FrametimeStatisticProviderTest.cs" />
+    <Compile Include="Statistics\SessionExtensionsTest.cs" />
     <Compile Include="TestHelper.cs" />
     <Compile Include="Updater\UpdateCheckTest.cs" />
     <Compile Include="ViewModel\CaptureViewModelTest.cs" />

--- a/source/CapFrameX.Test/Statistics/FrametimeStatisticProviderTest.cs
+++ b/source/CapFrameX.Test/Statistics/FrametimeStatisticProviderTest.cs
@@ -298,6 +298,47 @@ namespace CapFrameX.Test.Statistics
             Assert.IsFalse(result.Contains(10000));
         }
 
+        [TestMethod]
+        public void GetOutlierAdjustedSequence_DeciPercentile_RetainsConstantSequence()
+        {
+            var sequence = Enumerable.Repeat(16.67, 1000).ToList();
+
+            var result = _provider.GetOutlierAdjustedSequence(sequence, ERemoveOutlierMethod.DeciPercentile);
+
+            Assert.AreEqual(sequence.Count, result.Count);
+            CollectionAssert.AreEqual(sequence, result.ToList());
+        }
+
+        [TestMethod]
+        public void GetOutlierAdjustedSequence_DeciPercentile_ExactThousandSamples_RemovesExactlyOne()
+        {
+            var sequence = Enumerable.Repeat(10.0, 999).Concat(new[] { 500.0 }).ToList();
+
+            var result = _provider.GetOutlierAdjustedSequence(sequence, ERemoveOutlierMethod.DeciPercentile);
+
+            Assert.AreEqual(999, result.Count);
+            Assert.IsFalse(result.Contains(500.0));
+        }
+
+        [TestMethod]
+        public void GetOutlierAdjustedSequence_UnimplementedMethods_ReturnSequenceUnchanged()
+        {
+            var sequence = new List<double> { 10, 20, 30 };
+
+            foreach (var method in new[]
+            {
+                ERemoveOutlierMethod.InterquartileRange,
+                ERemoveOutlierMethod.ThreeSigma,
+                ERemoveOutlierMethod.TwoDotFiveSigma
+            })
+            {
+                var result = _provider.GetOutlierAdjustedSequence(sequence, method);
+
+                Assert.IsNotNull(result, $"Null returned for {method}");
+                CollectionAssert.AreEqual(sequence.ToList(), result.ToList(), $"Sequence changed for {method}");
+            }
+        }
+
         #endregion
 
         #region GetFpsThresholdCounts Tests
@@ -360,6 +401,24 @@ namespace CapFrameX.Test.Statistics
             var result = _provider.GetPercentageHighIntegralSequence(sequence, 0.99);
 
             Assert.IsFalse(double.IsNaN(result));
+        }
+
+        [TestMethod]
+        public void GetVariancePercentages_ClassifiesEachThresholdExactlyOnce()
+        {
+            var sequence = new List<double> { 0, 1, 4, 10, 20, 35 };
+
+            var result = _provider.GetVariancePercentages(sequence);
+
+            CollectionAssert.AreEqual(new[] { 0.2, 0.2, 0.2, 0.2, 0.2 }, result.ToArray());
+        }
+
+        [TestMethod]
+        public void GetVariancePercentages_NoValidPairs_ReturnsZeroes()
+        {
+            var result = _provider.GetVariancePercentages(new List<double> { 10, double.NaN, 11 });
+
+            CollectionAssert.AreEqual(new double[5], result.ToArray());
         }
 
         [TestMethod]

--- a/source/CapFrameX.Test/Statistics/FrametimeStatisticProviderTest.cs
+++ b/source/CapFrameX.Test/Statistics/FrametimeStatisticProviderTest.cs
@@ -422,6 +422,20 @@ namespace CapFrameX.Test.Statistics
         }
 
         [TestMethod]
+        public void GetVariancePercentages_MultipleRuns_DoesNotCreateBoundaryPair()
+        {
+            var runs = new IList<double>[]
+            {
+                new List<double> { 10, 11 },
+                new List<double> { 100, 101 }
+            };
+
+            var result = _provider.GetVariancePercentages(runs);
+
+            CollectionAssert.AreEqual(new[] { 1d, 0d, 0d, 0d, 0d }, result.ToArray());
+        }
+
+        [TestMethod]
         public void GetFpsMetricValue_VerySmallFrametimes_HandlesCorrectly()
         {
             // Very high FPS scenario (1ms frame times = 1000 FPS)

--- a/source/CapFrameX.Test/Statistics/SessionExtensionsTest.cs
+++ b/source/CapFrameX.Test/Statistics/SessionExtensionsTest.cs
@@ -1,0 +1,114 @@
+using CapFrameX.Data.Session.Classes;
+using CapFrameX.Statistics.NetStandard;
+using CapFrameX.Statistics.NetStandard.Contracts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Linq;
+
+namespace CapFrameX.Test.Statistics
+{
+    [TestClass]
+    public class SessionExtensionsTest
+    {
+        private IFrametimeStatisticProviderOptions _options;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var optionsMock = new Mock<IFrametimeStatisticProviderOptions>();
+            optionsMock.Setup(options => options.FpsValuesRoundingDigits).Returns(2);
+            optionsMock.Setup(options => options.IntervalAverageWindowTime).Returns(500);
+            _options = optionsMock.Object;
+        }
+
+        [TestMethod]
+        public void GetFrametimePointsTimeWindow_OutlierRemovalPreservesTimestamps()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d, 3d, 4d },
+                new[] { 10d, 10000d, 20d, 30d, 40d });
+
+            var points = session.GetFrametimePointsTimeWindow(0, 4, _options,
+                ERemoveOutlierMethod.DeciPercentile);
+
+            CollectionAssert.AreEqual(new[] { 0d, 2d, 3d, 4d },
+                points.Select(point => point.X).ToArray());
+            CollectionAssert.AreEqual(new[] { 10d, 20d, 30d, 40d },
+                points.Select(point => point.Y).ToArray());
+        }
+
+        [TestMethod]
+        public void GetFrametimeTimeWindow_RejectsInvalidTimingSamples()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d, 3d, 4d, 5d },
+                new[] { 10d, 0d, double.NaN, double.PositiveInfinity, -1d, 20d });
+
+            var frametimes = session.GetFrametimeTimeWindow(0, 5, _options);
+
+            CollectionAssert.AreEqual(new[] { 10d, 20d }, frametimes.ToArray());
+        }
+
+        [TestMethod]
+        public void GetActiveTimeWindows_PreserveZeroAndRejectInvalidSamples()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d, 3d },
+                new[] { 10d, 10d, 10d, 10d });
+            session.Runs[0].CaptureData.GpuActive = new[] { 0d, -1d, double.NaN, 5d };
+            session.Runs[0].CaptureData.CpuActive = new[] { 0d, double.PositiveInfinity, -2d, 4d };
+
+            var gpuValues = session.GetGpuActiveTimeTimeWindow(0, 3, _options);
+            var cpuPoints = session.GetCpuActiveTimePointsTimeWindow(0, 3, _options);
+
+            CollectionAssert.AreEqual(new[] { 0d, 5d }, gpuValues.ToArray());
+            CollectionAssert.AreEqual(new[] { 0d, 4d }, cpuPoints.Select(point => point.Y).ToArray());
+        }
+
+        [TestMethod]
+        public void GetDisplayTimeDistributionPoints_UsesDisplayChangeSamples()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d },
+                new[] { 10d, 10d, 10d });
+            session.Runs[0].CaptureData.MsBetweenDisplayChange = new[] { 5.01d, 5.09d, 30d };
+
+            var distribution = session.GetDisplayTimeDistributionPoints(0, 2, _options);
+
+            Assert.AreEqual(2, distribution.Count);
+            Assert.AreEqual((5.01 + 5.09) / 40.1 * 100, distribution[0].Y, 0.000001);
+            Assert.AreEqual(30 / 40.1 * 100, distribution[1].Y, 0.000001);
+        }
+
+        [TestMethod]
+        public void GetAnimationErrorTimeWindow_RejectsNonFiniteSamples()
+        {
+            var session = CreateSession(
+                new[] { 0d, 1d, 2d },
+                new[] { 10d, 10d, 10d });
+            session.Runs[0].CaptureData.AnimationError = new[]
+                { double.NaN, double.PositiveInfinity, -2d };
+
+            var values = session.GetAnimationErrorTimeWindow(0, 2);
+
+            CollectionAssert.AreEqual(new[] { -2d }, values.ToArray());
+        }
+
+        private static Session CreateSession(double[] times, double[] frametimes)
+        {
+            var captureData = new SessionCaptureData(times.Length)
+            {
+                TimeInSeconds = times,
+                MsBetweenPresents = frametimes,
+                MsBetweenDisplayChange = frametimes.ToArray(),
+                GpuActive = frametimes.ToArray(),
+                CpuActive = frametimes.ToArray()
+            };
+            var run = new SessionRun { CaptureData = captureData };
+            var session = new Session();
+            session.Runs.Add(run);
+            return session;
+        }
+    }
+}

--- a/source/CapFrameX.Test/ViewModel/ComparisonMetricSourceResolverTest.cs
+++ b/source/CapFrameX.Test/ViewModel/ComparisonMetricSourceResolverTest.cs
@@ -1,0 +1,75 @@
+using CapFrameX.Data.Session.Classes;
+using CapFrameX.Data.Session.Contracts;
+using CapFrameX.ViewModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace CapFrameX.Test.ViewModel
+{
+    [TestClass]
+    public class ComparisonMetricSourceResolverTest
+    {
+        [TestMethod]
+        public void ShouldUseDisplayChangeMetrics_AllSessionsHaveDisplayData_ReturnsTrue()
+        {
+            var sessions = new[] { CreateSession(16.6, 16.7), CreateSession(8.3, 8.4) };
+
+            Assert.IsTrue(ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(true, sessions));
+        }
+
+        [TestMethod]
+        public void ShouldUseDisplayChangeMetrics_OneSessionHasNoDisplayData_ReturnsFalse()
+        {
+            var sessions = new[]
+            {
+                CreateSession(16.6, 16.7),
+                CreateSession(0, double.NaN, double.PositiveInfinity)
+            };
+
+            Assert.IsFalse(ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(true, sessions));
+        }
+
+        [TestMethod]
+        public void ShouldUseDisplayChangeMetrics_OneRunHasNoDisplayData_ReturnsFalse()
+        {
+            var session = CreateSession(16.6, 16.7);
+            session.Runs.Add(CreateRun(0, 0));
+
+            Assert.IsFalse(ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(true,
+                new[] { session }));
+        }
+
+        [TestMethod]
+        public void ShouldUseDisplayChangeMetrics_NotRequestedOrNoSessions_ReturnsFalse()
+        {
+            Assert.IsFalse(ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(false,
+                new[] { CreateSession(16.6) }));
+            Assert.IsFalse(ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(true,
+                new ISession[0]));
+        }
+
+        private static ISession CreateSession(params double[] displayChangeTimes)
+        {
+            return new Session
+            {
+                Runs = new List<ISessionRun> { CreateRun(displayChangeTimes) }
+            };
+        }
+
+        private static ISessionRun CreateRun(params double[] displayChangeTimes)
+        {
+            var presentTimes = new double[displayChangeTimes.Length];
+            for (int i = 0; i < presentTimes.Length; i++)
+                presentTimes[i] = 16.6;
+
+            return new SessionRun
+            {
+                CaptureData = new SessionCaptureData(displayChangeTimes.Length)
+                {
+                    MsBetweenPresents = presentTimes,
+                    MsBetweenDisplayChange = displayChangeTimes
+                }
+            };
+        }
+    }
+}

--- a/source/CapFrameX.Test/ViewModel/FpsGraphDataContextTest.cs
+++ b/source/CapFrameX.Test/ViewModel/FpsGraphDataContextTest.cs
@@ -1,0 +1,37 @@
+using CapFrameX.Statistics.NetStandard;
+using CapFrameX.ViewModel.DataContext;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace CapFrameX.Test.ViewModel
+{
+    [TestClass]
+    public class FpsGraphDataContextTest
+    {
+        [TestMethod]
+        public void GetAlignedFinitePoints_MismatchedAndInvalidSeries_UsesTimestampIntersection()
+        {
+            var fpsPoints = new List<Point>
+            {
+                new Point(0, 60), new Point(1, 61), new Point(2, 62), new Point(3, 63)
+            };
+            var gpuPoints = new List<Point>
+            {
+                new Point(0, 100), new Point(2, double.PositiveInfinity), new Point(3, 103)
+            };
+            MethodInfo method = typeof(FpsGraphDataContext).GetMethod("GetAlignedFinitePoints",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            var result = (IList<Tuple<Point, Point>>)method.Invoke(null,
+                new object[] { fpsPoints, gpuPoints });
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(0d, result[0].Item1.X);
+            Assert.AreEqual(100d, result[0].Item2.Y);
+            Assert.AreEqual(3d, result[1].Item1.X);
+            Assert.AreEqual(103d, result[1].Item2.Y);
+        }
+    }
+}

--- a/source/CapFrameX.Test/ViewModel/FpsGraphDataContextTest.cs
+++ b/source/CapFrameX.Test/ViewModel/FpsGraphDataContextTest.cs
@@ -21,7 +21,7 @@ namespace CapFrameX.Test.ViewModel
             {
                 new Point(0, 100), new Point(2, double.PositiveInfinity), new Point(3, 103)
             };
-            MethodInfo method = typeof(FpsGraphDataContext).GetMethod("GetAlignedFinitePoints",
+            MethodInfo method = typeof(GraphDataContextBase).GetMethod("GetAlignedFinitePoints",
                 BindingFlags.NonPublic | BindingFlags.Static);
 
             var result = (IList<Tuple<Point, Point>>)method.Invoke(null,

--- a/source/CapFrameX.View/ComparisonView.xaml
+++ b/source/CapFrameX.View/ComparisonView.xaml
@@ -746,7 +746,18 @@
                        HorizontalAlignment="Right" VerticalAlignment="Center"
                        Text="{Binding ComparisonMetricSourceDescription}"
                        TextTrimming="CharacterEllipsis"
-                       ToolTip="All compared records use this timing source; mixed display/present comparisons are prevented." />
+                       ToolTip="All compared records use this timing source; mixed display/present comparisons are prevented.">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsComparisonMetricSourceFallback}" Value="True">
+                                <Setter Property="Foreground" Value="Orange" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
         </Grid>
 		<!-- Copmparison List -->
 		<StackPanel Margin="5 10 5 0" Grid.Column="1" Grid.RowSpan="2" Orientation="Vertical">

--- a/source/CapFrameX.View/ComparisonView.xaml
+++ b/source/CapFrameX.View/ComparisonView.xaml
@@ -742,6 +742,11 @@
                     </Style>
                 </StackPanel.Style>
             </StackPanel>
+            <TextBlock Grid.Column="8" Margin="10 10 10 0"
+                       HorizontalAlignment="Right" VerticalAlignment="Center"
+                       Text="{Binding ComparisonMetricSourceDescription}"
+                       TextTrimming="CharacterEllipsis"
+                       ToolTip="All compared records use this timing source; mixed display/present comparisons are prevented." />
         </Grid>
 		<!-- Copmparison List -->
 		<StackPanel Margin="5 10 5 0" Grid.Column="1" Grid.RowSpan="2" Orientation="Vertical">

--- a/source/CapFrameX.ViewModel/CapFrameX.ViewModel.csproj
+++ b/source/CapFrameX.ViewModel/CapFrameX.ViewModel.csproj
@@ -195,6 +195,7 @@
     <Compile Include="CaptureViewModel.cs" />
     <Compile Include="ColorRessource.cs" />
     <Compile Include="ComparisonColorManager.cs" />
+    <Compile Include="ComparisonMetricSourceResolver.cs" />
     <Compile Include="ComparisonRecordInfoWrapper.cs" />
     <Compile Include="ComparisonViewModel.cs" />
     <Compile Include="ComparisonViewModelLabel.cs" />

--- a/source/CapFrameX.ViewModel/ComparisonMetricSourceResolver.cs
+++ b/source/CapFrameX.ViewModel/ComparisonMetricSourceResolver.cs
@@ -1,0 +1,56 @@
+using CapFrameX.Data.Session.Contracts;
+using System.Collections.Generic;
+
+namespace CapFrameX.ViewModel
+{
+    public static class ComparisonMetricSourceResolver
+    {
+        public static bool ShouldUseDisplayChangeMetrics(bool requested, IEnumerable<ISession> sessions)
+        {
+            if (!requested || sessions == null)
+                return false;
+
+            bool hasSession = false;
+            foreach (ISession session in sessions)
+            {
+                hasSession = true;
+                if (!HasValidDisplayChangeSamples(session))
+                    return false;
+            }
+
+            return hasSession;
+        }
+
+        private static bool HasValidDisplayChangeSamples(ISession session)
+        {
+            if (session?.Runs == null || session.Runs.Count == 0)
+                return false;
+
+            foreach (ISessionRun run in session.Runs)
+            {
+                if (!HasValidTimingSample(run?.CaptureData?.MsBetweenPresents)
+                    || !HasValidTimingSample(run?.CaptureData?.MsBetweenDisplayChange))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool HasValidTimingSample(double[] values)
+        {
+            if (values == null)
+                return false;
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                double value = values[i];
+                if (value > 0 && !double.IsNaN(value) && !double.IsInfinity(value))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/source/CapFrameX.ViewModel/ComparisonViewModel.cs
+++ b/source/CapFrameX.ViewModel/ComparisonViewModel.cs
@@ -2307,16 +2307,13 @@ namespace CapFrameX.ViewModel
         {
             var session = wrappedComparisonInfo.WrappedRecordInfo.Session;
             double lastFrameStart;
-            IList<double> samples = new List<double>();
+            IEnumerable<IList<double>> samples = Enumerable.Empty<IList<double>>();
             if (TryGetLastFrameStart(session, out lastFrameStart))
             {
                 double endTime = LastSeconds <= 0 || LastSeconds > lastFrameStart
                     ? lastFrameStart : LastSeconds;
-                samples = _useDisplayChangeSamplesForComparison
-                    ? session.GetDisplayChangeTimeWindow(FirstSeconds, endTime,
-                        _appConfiguration, ERemoveOutlierMethod.None)
-                    : session.GetFrametimeTimeWindow(FirstSeconds, endTime,
-                        _appConfiguration, ERemoveOutlierMethod.None);
+                samples = GetVarianceSequences(session,
+                    _useDisplayChangeSamplesForComparison, FirstSeconds, endTime);
             }
             var variances = _frametimeStatisticProvider.GetVariancePercentages(samples);
 

--- a/source/CapFrameX.ViewModel/ComparisonViewModel.cs
+++ b/source/CapFrameX.ViewModel/ComparisonViewModel.cs
@@ -30,6 +30,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reactive;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Windows;
 using System.Windows.Controls;
@@ -112,6 +113,8 @@ namespace CapFrameX.ViewModel
         private bool _isDistributionChartDirty = true;
         private bool _isFpsChartDirty = true;
         private bool _isFrametimeChartDirty = true;
+        private bool _useDisplayChangeSamplesForComparison;
+        private string _comparisonMetricSourceDescription = "Source: Presents";
 
         public Array FirstMetricItems => Enum.GetValues(typeof(EMetric))
             .Cast<EMetric>().Where(metric => metric != EMetric.None && metric != EMetric.GpuActiveAverage && metric != EMetric.GpuActiveOnePercentLowAverage && metric != EMetric.GpuActiveP1)
@@ -342,6 +345,19 @@ namespace CapFrameX.ViewModel
             set
             {
                 _columnChartYAxisTitle = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public string ComparisonMetricSourceDescription
+        {
+            get { return _comparisonMetricSourceDescription; }
+            private set
+            {
+                if (_comparisonMetricSourceDescription == value)
+                    return;
+
+                _comparisonMetricSourceDescription = value;
                 RaisePropertyChanged();
             }
         }
@@ -870,6 +886,19 @@ namespace CapFrameX.ViewModel
             SubscribeToUpdateRecordInfos();
             SubscribeToThemeChanged();
 
+            var configurationChanges = _appConfiguration.OnValueChanged;
+            if (configurationChanges != null)
+            {
+                configurationChanges
+                    .Where(change => change.key == nameof(IAppConfiguration.UseDisplayChangeMetrics))
+                    .Subscribe(_ =>
+                    {
+                        SetChartUpdateFlags();
+                        UpdateCharts();
+                    }, error => _logger?.LogError(error,
+                        "The comparison display-metric update subscription stopped unexpectedly."));
+            }
+
             LineGraphColors = new ObservableCollection<ComparisonColorItems>(
                 _appConfiguration.ComparisonLineGraphColors
                     .Select(c => new ComparisonColorItems
@@ -1059,6 +1088,7 @@ namespace CapFrameX.ViewModel
                 ComparisonDistributionModel.Annotations.Add(Line); ;
             }
 
+            UpdateComparisonMetricSourceLabels();
         }
 
         private void SetRowSeries()
@@ -1258,6 +1288,14 @@ namespace CapFrameX.ViewModel
         {
             if (!_doUpdateCharts)
                 return;
+
+            bool sourceChanged = UpdateComparisonMetricSource();
+            if (sourceChanged)
+            {
+                foreach (ComparisonRecordInfoWrapper record in ComparisonRecords)
+                    SetMetrics(record);
+            }
+
             ResetBarChartSeriesTitles();
 
             //Clear series and reset axes of all charts
@@ -1309,6 +1347,78 @@ namespace CapFrameX.ViewModel
             OnComparisonContextChanged();
 
             RaisePropertyChanged(nameof(MetricAndLabelOptionsEnabled));
+        }
+
+        private bool UpdateComparisonMetricSource(ComparisonRecordInfoWrapper additionalRecord = null)
+        {
+            IEnumerable<CapFrameX.Data.Session.Contracts.ISession> sessions = ComparisonRecords
+                .Select(record => record.WrappedRecordInfo.Session);
+            if (additionalRecord != null)
+                sessions = sessions.Concat(new[] { additionalRecord.WrappedRecordInfo.Session });
+
+            bool useDisplayTimes = ComparisonMetricSourceResolver.ShouldUseDisplayChangeMetrics(
+                _appConfiguration.UseDisplayChangeMetrics, sessions);
+            bool sourceChanged = useDisplayTimes != _useDisplayChangeSamplesForComparison;
+            _useDisplayChangeSamplesForComparison = useDisplayTimes;
+
+            bool hasRecords = ComparisonRecords.Any() || additionalRecord != null;
+            if (useDisplayTimes)
+                ComparisonMetricSourceDescription = "Source: Display changes (Average FPS: Presents)";
+            else if (_appConfiguration.UseDisplayChangeMetrics && hasRecords)
+                ComparisonMetricSourceDescription = "Source: Presents (display data unavailable)";
+            else
+                ComparisonMetricSourceDescription = "Source: Presents";
+
+            UpdateComparisonMetricSourceLabels();
+            return sourceChanged;
+        }
+
+        private void UpdateComparisonMetricSourceLabels()
+        {
+            string timingSource = _useDisplayChangeSamplesForComparison
+                ? "Display time" : "Present frametime";
+            string fpsSource = _useDisplayChangeSamplesForComparison
+                ? "Display FPS" : "Present FPS";
+
+            var frametimeAxis = ComparisonFrametimesModel?.Axes.FirstOrDefault(axis => axis.Key == "yAxis");
+            if (frametimeAxis != null)
+                frametimeAxis.Title = ShowGpuActiveLineCharts ? "GPU active time [ms]" : timingSource + " [ms]";
+
+            var fpsAxis = ComparisonFpsModel?.Axes.FirstOrDefault(axis => axis.Key == "yAxis");
+            if (fpsAxis != null)
+                fpsAxis.Title = fpsSource + " [1/s]";
+
+            var distributionXAxis = ComparisonDistributionModel?.Axes.FirstOrDefault(axis => axis.Key == "xAxis");
+            if (distributionXAxis != null)
+                distributionXAxis.Title = timingSource + " [ms]";
+
+            var distributionYAxis = ComparisonDistributionModel?.Axes.FirstOrDefault(axis => axis.Key == "yAxis");
+            if (distributionYAxis != null)
+                distributionYAxis.Title = timingSource + " Distribution [%]";
+
+            if (!ShowGpuActiveLineCharts)
+            {
+                ComparisonLShapeYAxisLabel = SelectedChartView == "FPS"
+                    ? fpsSource + Environment.NewLine + " "
+                    : timingSource + " (ms)" + Environment.NewLine + " ";
+            }
+        }
+
+        private static bool TryGetLastFrameStart(CapFrameX.Data.Session.Contracts.ISession session,
+            out double lastFrameStart)
+        {
+            lastFrameStart = double.NaN;
+            if (session?.Runs == null)
+                return false;
+
+            foreach (var run in session.Runs)
+            {
+                double[] times = run?.CaptureData?.TimeInSeconds;
+                if (times != null && times.Length > 0)
+                    lastFrameStart = times[times.Length - 1];
+            }
+
+            return !double.IsNaN(lastFrameStart) && !double.IsInfinity(lastFrameStart);
         }
 
         private void OnChartItemChanged()
@@ -1383,7 +1493,7 @@ namespace CapFrameX.ViewModel
                         }
                         else
                         {
-                            var samples = _appConfiguration.UseDisplayChangeMetrics
+                            var samples = _useDisplayChangeSamplesForComparison
                                 ? displayChangeTimeWindow : frametimeTimeWindow;
 
                             metricValue = GetMetricValue(samples, metric);
@@ -2018,8 +2128,11 @@ namespace CapFrameX.ViewModel
             }
             else
             {
-                frametimePoints = session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None)
-                   .Select(pnt => new Point(pnt.X, pnt.Y));
+                frametimePoints = _useDisplayChangeSamplesForComparison
+                    ? session.GetDisplayChangeTimePointsTimeWindow(startTime, endTime, _appConfiguration,
+                        ERemoveOutlierMethod.None)
+                    : session.GetFrametimePointsTimeWindow(startTime, endTime, _appConfiguration,
+                        ERemoveOutlierMethod.None);
             }
 
             var chartTitle = string.Empty;
@@ -2053,8 +2166,11 @@ namespace CapFrameX.ViewModel
             //	fpsPoints = session.GetGpuActiveFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode)
             //	   .Select(pnt => new Point(pnt.X, pnt.Y));
             //else
-            fpsPoints = session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None, SelectedFilterMode)
-                .Select(pnt => new Point(pnt.X, pnt.Y));
+            fpsPoints = _useDisplayChangeSamplesForComparison
+                ? session.GetDisplayFpsPointsTimeWindow(startTime, endTime, _appConfiguration,
+                    ERemoveOutlierMethod.None, SelectedFilterMode)
+                : session.GetFpsPointsTimeWindow(startTime, endTime, _appConfiguration,
+                    ERemoveOutlierMethod.None, SelectedFilterMode);
 
             var chartTitle = string.Empty;
 
@@ -2086,8 +2202,11 @@ namespace CapFrameX.ViewModel
             IEnumerable<Point> distributionPoints = null;
 
 
-            distributionPoints = session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None)
-                .Select(pnt => new Point(pnt.X, pnt.Y));
+            distributionPoints = _useDisplayChangeSamplesForComparison
+                ? session.GetDisplayTimeDistributionPoints(startTime, endTime, _appConfiguration,
+                    ERemoveOutlierMethod.None)
+                : session.GetFrametimeDistributionPoints(startTime, endTime, _appConfiguration,
+                    ERemoveOutlierMethod.None);
 
             var chartTitle = string.Empty;
 
@@ -2123,7 +2242,11 @@ namespace CapFrameX.ViewModel
             }
             else
             {
-                frametimeTimeWindow = wrappedComparisonInfo.WrappedRecordInfo.Session.GetFrametimeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
+                frametimeTimeWindow = _useDisplayChangeSamplesForComparison
+                    ? wrappedComparisonInfo.WrappedRecordInfo.Session.GetDisplayChangeTimeWindow(
+                        startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None)
+                    : wrappedComparisonInfo.WrappedRecordInfo.Session.GetFrametimeTimeWindow(
+                        startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
             }
 
             var fpsTimeWindow = frametimeTimeWindow?.Select(ft => 1000 / ft).ToList();
@@ -2149,6 +2272,7 @@ namespace CapFrameX.ViewModel
                 PointForeground = wrappedComparisonInfo.IsHideModeSelected ? Brushes.Transparent : wrappedComparisonInfo.Color,
                 LabelPoint = chartPoint => string.Format(CultureInfo.InvariantCulture, "{0:0.##}", chartPoint.Y, unit)
             });
+
         }
 
         private void AddToColumnCharts(ComparisonRecordInfoWrapper wrappedComparisonInfo)
@@ -2181,16 +2305,20 @@ namespace CapFrameX.ViewModel
 
         private void AddToVarianceCharts(ComparisonRecordInfoWrapper wrappedComparisonInfo)
         {
-            IList<double> variances;
-
-            if (_appConfiguration.UseDisplayChangeMetrics)
+            var session = wrappedComparisonInfo.WrappedRecordInfo.Session;
+            double lastFrameStart;
+            IList<double> samples = new List<double>();
+            if (TryGetLastFrameStart(session, out lastFrameStart))
             {
-                variances = _frametimeStatisticProvider.GetDisplayTimeVariancePercentages(wrappedComparisonInfo.WrappedRecordInfo.Session);
+                double endTime = LastSeconds <= 0 || LastSeconds > lastFrameStart
+                    ? lastFrameStart : LastSeconds;
+                samples = _useDisplayChangeSamplesForComparison
+                    ? session.GetDisplayChangeTimeWindow(FirstSeconds, endTime,
+                        _appConfiguration, ERemoveOutlierMethod.None)
+                    : session.GetFrametimeTimeWindow(FirstSeconds, endTime,
+                        _appConfiguration, ERemoveOutlierMethod.None);
             }
-            else
-            {
-                variances = _frametimeStatisticProvider.GetFrametimeVariancePercentages(wrappedComparisonInfo.WrappedRecordInfo.Session);
-            }                
+            var variances = _frametimeStatisticProvider.GetVariancePercentages(samples);
 
             VarianceStatisticCollection[0].Values.Insert(0, variances[0]);
             VarianceStatisticCollection[1].Values.Insert(0, variances[1]);
@@ -2228,7 +2356,17 @@ namespace CapFrameX.ViewModel
             else
                 description = $"{metric.GetDescription()} FPS";
 
-            return description;
+            string source;
+            if (metric == EMetric.GpuActiveAverage || metric == EMetric.GpuActiveP1
+                || metric == EMetric.GpuActiveOnePercentLowAverage)
+                source = "GPU active";
+            else if (metric == EMetric.Average || metric == EMetric.CpuFpsPerWatt
+                || metric == EMetric.GpuFpsPerWatt)
+                source = "Present";
+            else
+                source = _useDisplayChangeSamplesForComparison ? "Display" : "Present";
+
+            return description + " (" + source + ")";
         }
 
         private EMetric GetMetricByIndex(int index)

--- a/source/CapFrameX.ViewModel/ComparisonViewModel.cs
+++ b/source/CapFrameX.ViewModel/ComparisonViewModel.cs
@@ -891,6 +891,7 @@ namespace CapFrameX.ViewModel
             {
                 configurationChanges
                     .Where(change => change.key == nameof(IAppConfiguration.UseDisplayChangeMetrics))
+                    .ObserveOnDispatcher()
                     .Subscribe(_ =>
                     {
                         SetChartUpdateFlags();

--- a/source/CapFrameX.ViewModel/ComparisonViewModel.cs
+++ b/source/CapFrameX.ViewModel/ComparisonViewModel.cs
@@ -115,6 +115,7 @@ namespace CapFrameX.ViewModel
         private bool _isFrametimeChartDirty = true;
         private bool _useDisplayChangeSamplesForComparison;
         private string _comparisonMetricSourceDescription = "Source: Presents";
+        private bool _isComparisonMetricSourceFallback;
 
         public Array FirstMetricItems => Enum.GetValues(typeof(EMetric))
             .Cast<EMetric>().Where(metric => metric != EMetric.None && metric != EMetric.GpuActiveAverage && metric != EMetric.GpuActiveOnePercentLowAverage && metric != EMetric.GpuActiveP1)
@@ -358,6 +359,19 @@ namespace CapFrameX.ViewModel
                     return;
 
                 _comparisonMetricSourceDescription = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public bool IsComparisonMetricSourceFallback
+        {
+            get { return _isComparisonMetricSourceFallback; }
+            private set
+            {
+                if (_isComparisonMetricSourceFallback == value)
+                    return;
+
+                _isComparisonMetricSourceFallback = value;
                 RaisePropertyChanged();
             }
         }
@@ -1364,11 +1378,20 @@ namespace CapFrameX.ViewModel
 
             bool hasRecords = ComparisonRecords.Any() || additionalRecord != null;
             if (useDisplayTimes)
+            {
                 ComparisonMetricSourceDescription = "Source: Display changes (Average FPS: Presents)";
+                IsComparisonMetricSourceFallback = false;
+            }
             else if (_appConfiguration.UseDisplayChangeMetrics && hasRecords)
+            {
                 ComparisonMetricSourceDescription = "Source: Presents (display data unavailable)";
+                IsComparisonMetricSourceFallback = true;
+            }
             else
+            {
                 ComparisonMetricSourceDescription = "Source: Presents";
+                IsComparisonMetricSourceFallback = false;
+            }
 
             UpdateComparisonMetricSourceLabels();
             return sourceChanged;

--- a/source/CapFrameX.ViewModel/ComparisonViewModelItems.cs
+++ b/source/CapFrameX.ViewModel/ComparisonViewModelItems.cs
@@ -1,4 +1,5 @@
 ﻿using CapFrameX.Contracts.Data;
+using CapFrameX.Data.Session.Contracts;
 using CapFrameX.Sensor.Reporting;
 using CapFrameX.Statistics.NetStandard;
 using CapFrameX.Statistics.NetStandard.Contracts;
@@ -195,12 +196,51 @@ namespace CapFrameX.ViewModel
                 }
             }
 
-            var varianceSamples = _useDisplayChangeSamplesForComparison
-                ? displayChangeTimeWindow : frametimeTimeWindow;
-            var variances = _frametimeStatisticProvider.GetVariancePercentages(varianceSamples);
+            var varianceSequences = GetVarianceSequences(
+                wrappedComparisonRecordInfo.WrappedRecordInfo.Session,
+                _useDisplayChangeSamplesForComparison, startTime, endTime);
+            var variances = _frametimeStatisticProvider.GetVariancePercentages(varianceSequences);
 
             wrappedComparisonRecordInfo.WrappedRecordInfo.SortingVariances
                 = variances[0] + variances[1];
+        }
+
+        private static IEnumerable<IList<double>> GetVarianceSequences(ISession session,
+            bool useDisplayChangeSamples, double startTime, double endTime)
+        {
+            foreach (ISessionRun run in session.Runs)
+            {
+                ISessionCaptureData captureData = run?.CaptureData;
+                if (captureData == null)
+                {
+                    yield return new double[0];
+                    continue;
+                }
+
+                IList<double> times = captureData.TimeInSeconds ?? new double[0];
+                IList<double> values = useDisplayChangeSamples
+                    ? captureData.MsBetweenDisplayChange : captureData.MsBetweenPresents;
+                if (values == null)
+                {
+                    yield return new double[0];
+                    continue;
+                }
+
+                int count = Math.Min(times.Count, values.Count);
+                var sequence = new List<double>(count);
+                for (int i = 0; i < count; i++)
+                {
+                    double time = times[i];
+                    double value = values[i];
+                    if (time >= startTime && time <= endTime && value > 0
+                        && !double.IsNaN(value) && !double.IsInfinity(value))
+                    {
+                        sequence.Add(value);
+                    }
+                }
+
+                yield return sequence;
+            }
         }
 
         private void InsertComparisonRecordsSorted(ComparisonRecordInfoWrapper wrappedComparisonRecordInfo)

--- a/source/CapFrameX.ViewModel/ComparisonViewModelItems.cs
+++ b/source/CapFrameX.ViewModel/ComparisonViewModelItems.cs
@@ -26,6 +26,12 @@ namespace CapFrameX.ViewModel
             var wrappedComparisonRecordInfo = GetWrappedRecordInfo(comparisonRecordInfo);
 
             // Insert into list (sorted)
+            bool sourceChanged = UpdateComparisonMetricSource(wrappedComparisonRecordInfo);
+            if (sourceChanged)
+            {
+                foreach (ComparisonRecordInfoWrapper existingRecord in ComparisonRecords)
+                    SetMetrics(existingRecord);
+            }
             SetMetrics(wrappedComparisonRecordInfo);
             InsertComparisonRecordsSorted(wrappedComparisonRecordInfo);
 
@@ -55,11 +61,24 @@ namespace CapFrameX.ViewModel
         private void SetMetrics(ComparisonRecordInfoWrapper wrappedComparisonRecordInfo)
         {
             double startTime = FirstSeconds;
-            double lastFrameStart = wrappedComparisonRecordInfo.WrappedRecordInfo.Session.Runs.SelectMany(r => r.CaptureData.TimeInSeconds).Last();
-            double endTime = LastSeconds > lastFrameStart ? lastFrameStart : lastFrameStart + LastSeconds;
+            double lastFrameStart;
+            if (!TryGetLastFrameStart(wrappedComparisonRecordInfo.WrappedRecordInfo.Session, out lastFrameStart))
+            {
+                wrappedComparisonRecordInfo.WrappedRecordInfo.FirstMetric = double.NaN;
+                wrappedComparisonRecordInfo.WrappedRecordInfo.SecondMetric = double.NaN;
+                wrappedComparisonRecordInfo.WrappedRecordInfo.ThirdMetric = double.NaN;
+                wrappedComparisonRecordInfo.WrappedRecordInfo.SortingVariances = 0;
+                return;
+            }
+
+            double endTime = LastSeconds <= 0 || LastSeconds > lastFrameStart
+                ? lastFrameStart : LastSeconds;
 
             var frametimeTimeWindow = wrappedComparisonRecordInfo.WrappedRecordInfo.Session.GetFrametimeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
-            var displayChangeTimeWindow = wrappedComparisonRecordInfo.WrappedRecordInfo.Session.GetDisplayChangeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
+            var displayChangeTimeWindow = _useDisplayChangeSamplesForComparison
+                ? wrappedComparisonRecordInfo.WrappedRecordInfo.Session.GetDisplayChangeTimeWindow(
+                    startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None)
+                : null;
             var gpuActiveTimeWindow = wrappedComparisonRecordInfo.WrappedRecordInfo.Session.GetGpuActiveTimeTimeWindow(startTime, endTime, _appConfiguration, ERemoveOutlierMethod.None);
 
             double GeMetricValue(IList<double> sequence, EMetric metric) =>
@@ -94,7 +113,7 @@ namespace CapFrameX.ViewModel
                 }
                 else
                 {
-                    var samples = _appConfiguration.UseDisplayChangeMetrics
+                    var samples = _useDisplayChangeSamplesForComparison
                         ? displayChangeTimeWindow : frametimeTimeWindow;
 
                     wrappedComparisonRecordInfo.WrappedRecordInfo.FirstMetric =
@@ -131,7 +150,7 @@ namespace CapFrameX.ViewModel
                 }
                 else
                 {
-                    var samples = _appConfiguration.UseDisplayChangeMetrics
+                    var samples = _useDisplayChangeSamplesForComparison
                         ? displayChangeTimeWindow : frametimeTimeWindow;
 
                     wrappedComparisonRecordInfo.WrappedRecordInfo.SecondMetric =
@@ -168,7 +187,7 @@ namespace CapFrameX.ViewModel
                 }
                 else
                 {
-                    var samples = _appConfiguration.UseDisplayChangeMetrics
+                    var samples = _useDisplayChangeSamplesForComparison
                         ? displayChangeTimeWindow : frametimeTimeWindow;
 
                     wrappedComparisonRecordInfo.WrappedRecordInfo.ThirdMetric =
@@ -176,16 +195,9 @@ namespace CapFrameX.ViewModel
                 }
             }
 
-            IList<double> variances;
-
-            if (_appConfiguration.UseDisplayChangeMetrics)
-            {
-                variances = _frametimeStatisticProvider.GetDisplayTimeVariancePercentages(wrappedComparisonRecordInfo.WrappedRecordInfo.Session);
-            }
-            else
-            {
-                variances = _frametimeStatisticProvider.GetFrametimeVariancePercentages(wrappedComparisonRecordInfo.WrappedRecordInfo.Session);
-            }
+            var varianceSamples = _useDisplayChangeSamplesForComparison
+                ? displayChangeTimeWindow : frametimeTimeWindow;
+            var variances = _frametimeStatisticProvider.GetVariancePercentages(varianceSamples);
 
             wrappedComparisonRecordInfo.WrappedRecordInfo.SortingVariances
                 = variances[0] + variances[1];

--- a/source/CapFrameX.ViewModel/DataContext/FpsGraphDataContext.cs
+++ b/source/CapFrameX.ViewModel/DataContext/FpsGraphDataContext.cs
@@ -3,6 +3,7 @@ using OxyPlot;
 using OxyPlot.Axes;
 using Prism.Commands;
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Windows.Input;
 using System.Globalization;
@@ -13,6 +14,7 @@ using CapFrameX.Statistics.PlotBuilder;
 using CapFrameX.Statistics.PlotBuilder.Contracts;
 using Prism.Events;
 using CapFrameX.Extensions.NetStandard;
+using CapFrameX.Statistics.NetStandard;
 using CapFrameX.Statistics.NetStandard.Contracts;
 
 namespace CapFrameX.ViewModel.DataContext
@@ -133,14 +135,15 @@ namespace CapFrameX.ViewModel.DataContext
             if (RecordSession == null)
                 return;
 
-            var fps = RecordDataServer.GetFpsTimeWindow();
-            var gpuActiveFps = RecordDataServer.GetGpuActiveFpsTimeWindow();
+            var alignedPoints = GetAlignedFinitePoints(
+                RecordDataServer.GetFpsPointTimeWindow(),
+                RecordDataServer.GetGpuActiveFpsPointTimeWindow());
             StringBuilder builder = new StringBuilder();
 
-            for (int i = 0; i < fps.Count; i++)
+            foreach (var points in alignedPoints)
             {
-                builder.Append(Math.Round(fps[i], 2, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture) + "\t" +
-                    Math.Round(gpuActiveFps[i], 2, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
+                builder.Append(Math.Round(points.Item1.Y, 2, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture) + "\t" +
+                    Math.Round(points.Item2.Y, 2, MidpointRounding.AwayFromZero).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
             }
 
             Clipboard.SetDataObject(builder.ToString(), false);
@@ -168,18 +171,57 @@ namespace CapFrameX.ViewModel.DataContext
             if (RecordSession == null)
                 return;
 
-            var fpsPoints = RecordDataServer.GetFpsPointTimeWindow();
-            var gpuActiveFpsPoints = RecordDataServer.GetGpuActiveFpsPointTimeWindow();
+            var alignedPoints = GetAlignedFinitePoints(
+                RecordDataServer.GetFpsPointTimeWindow(),
+                RecordDataServer.GetGpuActiveFpsPointTimeWindow());
             StringBuilder builder = new StringBuilder();
 
-            for (int i = 0; i < fpsPoints.Count; i++)
+            foreach (var points in alignedPoints)
             {
-                builder.Append(Math.Round(fpsPoints[i].X, 2).ToString(CultureInfo.InvariantCulture) + "\t" +
-                    Math.Round(fpsPoints[i].Y, 2).ToString(CultureInfo.InvariantCulture) + "\t"+
-                    Math.Round(gpuActiveFpsPoints[i].Y, 2).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
+                builder.Append(Math.Round(points.Item1.X, 2).ToString(CultureInfo.InvariantCulture) + "\t" +
+                    Math.Round(points.Item1.Y, 2).ToString(CultureInfo.InvariantCulture) + "\t"+
+                    Math.Round(points.Item2.Y, 2).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
             }
 
             Clipboard.SetDataObject(builder.ToString(), false);
+        }
+
+        private static IList<Tuple<Point, Point>> GetAlignedFinitePoints(
+            IList<Point> fpsPoints, IList<Point> gpuActiveFpsPoints)
+        {
+            var alignedPoints = new List<Tuple<Point, Point>>();
+            if (fpsPoints == null || gpuActiveFpsPoints == null)
+                return alignedPoints;
+
+            int fpsIndex = 0;
+            int gpuIndex = 0;
+            while (fpsIndex < fpsPoints.Count && gpuIndex < gpuActiveFpsPoints.Count)
+            {
+                Point fpsPoint = fpsPoints[fpsIndex];
+                Point gpuPoint = gpuActiveFpsPoints[gpuIndex];
+                if (fpsPoint.X < gpuPoint.X)
+                {
+                    fpsIndex++;
+                    continue;
+                }
+                if (gpuPoint.X < fpsPoint.X)
+                {
+                    gpuIndex++;
+                    continue;
+                }
+
+                if (IsFinite(fpsPoint.Y) && IsFinite(gpuPoint.Y))
+                    alignedPoints.Add(Tuple.Create(fpsPoint, gpuPoint));
+                fpsIndex++;
+                gpuIndex++;
+            }
+
+            return alignedPoints;
+        }
+
+        private static bool IsFinite(double value)
+        {
+            return !double.IsNaN(value) && !double.IsInfinity(value);
         }
     }
 }

--- a/source/CapFrameX.ViewModel/DataContext/FpsGraphDataContext.cs
+++ b/source/CapFrameX.ViewModel/DataContext/FpsGraphDataContext.cs
@@ -185,43 +185,5 @@ namespace CapFrameX.ViewModel.DataContext
 
             Clipboard.SetDataObject(builder.ToString(), false);
         }
-
-        private static IList<Tuple<Point, Point>> GetAlignedFinitePoints(
-            IList<Point> fpsPoints, IList<Point> gpuActiveFpsPoints)
-        {
-            var alignedPoints = new List<Tuple<Point, Point>>();
-            if (fpsPoints == null || gpuActiveFpsPoints == null)
-                return alignedPoints;
-
-            int fpsIndex = 0;
-            int gpuIndex = 0;
-            while (fpsIndex < fpsPoints.Count && gpuIndex < gpuActiveFpsPoints.Count)
-            {
-                Point fpsPoint = fpsPoints[fpsIndex];
-                Point gpuPoint = gpuActiveFpsPoints[gpuIndex];
-                if (fpsPoint.X < gpuPoint.X)
-                {
-                    fpsIndex++;
-                    continue;
-                }
-                if (gpuPoint.X < fpsPoint.X)
-                {
-                    gpuIndex++;
-                    continue;
-                }
-
-                if (IsFinite(fpsPoint.Y) && IsFinite(gpuPoint.Y))
-                    alignedPoints.Add(Tuple.Create(fpsPoint, gpuPoint));
-                fpsIndex++;
-                gpuIndex++;
-            }
-
-            return alignedPoints;
-        }
-
-        private static bool IsFinite(double value)
-        {
-            return !double.IsNaN(value) && !double.IsInfinity(value);
-        }
     }
 }

--- a/source/CapFrameX.ViewModel/DataContext/FrametimeGraphDataContext.cs
+++ b/source/CapFrameX.ViewModel/DataContext/FrametimeGraphDataContext.cs
@@ -137,14 +137,15 @@ namespace CapFrameX.ViewModel.DataContext
             if (RecordSession == null)
                 return;
 
-            var frametimes = RecordDataServer.GetFrametimeTimeWindow();
-            var gpuActiveTimes = RecordDataServer.GetGpuActiveTimeTimeWindow();
+            var alignedPoints = GetAlignedFinitePoints(
+                RecordDataServer.GetFrametimePointTimeWindow(),
+                RecordDataServer.GetGpuActiveTimePointTimeWindow());
             StringBuilder builder = new StringBuilder();
 
-            for (int i = 0; i < frametimes.Count; i++)
+            foreach (var points in alignedPoints)
             {
-                builder.Append(Math.Round(frametimes[i], 2).ToString(CultureInfo.InvariantCulture) + "\t" +
-                    Math.Round(gpuActiveTimes[i], 2).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
+                builder.Append(Math.Round(points.Item1.Y, 2).ToString(CultureInfo.InvariantCulture) + "\t" +
+                    Math.Round(points.Item2.Y, 2).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
             }
 
             Clipboard.SetDataObject(builder.ToString(), false);
@@ -172,15 +173,16 @@ namespace CapFrameX.ViewModel.DataContext
             if (RecordSession == null)
                 return;
 
-            var frametimePoints = RecordDataServer.GetFrametimePointTimeWindow();
-            var gpuActiveTimePoints = RecordDataServer.GetGpuActiveTimePointTimeWindow();
+            var alignedPoints = GetAlignedFinitePoints(
+                RecordDataServer.GetFrametimePointTimeWindow(),
+                RecordDataServer.GetGpuActiveTimePointTimeWindow());
             StringBuilder builder = new StringBuilder();
 
-            for (int i = 0; i < frametimePoints.Count; i++)
+            foreach (var points in alignedPoints)
             {
-                builder.Append(Math.Round(gpuActiveTimePoints[i].X, 2).ToString(CultureInfo.InvariantCulture) + "\t" +
-                    Math.Round(frametimePoints[i].Y, 2).ToString(CultureInfo.InvariantCulture) + "\t"+
-                    Math.Round(gpuActiveTimePoints[i].Y, 2).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
+                builder.Append(Math.Round(points.Item2.X, 2).ToString(CultureInfo.InvariantCulture) + "\t" +
+                    Math.Round(points.Item1.Y, 2).ToString(CultureInfo.InvariantCulture) + "\t"+
+                    Math.Round(points.Item2.Y, 2).ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
             }
 
             Clipboard.SetDataObject(builder.ToString(), false);

--- a/source/CapFrameX.ViewModel/DataContext/GraphDataContextBase.cs
+++ b/source/CapFrameX.ViewModel/DataContext/GraphDataContextBase.cs
@@ -2,11 +2,14 @@
 using CapFrameX.Data;
 using CapFrameX.Data.Session.Contracts;
 using CapFrameX.EventAggregation.Messages;
+using CapFrameX.Statistics.NetStandard;
 using CapFrameX.Statistics.NetStandard.Contracts;
 using CapFrameX.Statistics.PlotBuilder.Contracts;
 using OxyPlot;
 using Prism.Events;
 using Prism.Mvvm;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace CapFrameX.ViewModel.DataContext
@@ -78,6 +81,47 @@ namespace CapFrameX.ViewModel.DataContext
                     }
                     catch { }
                 });
+        }
+
+        // Both series originate from the same TimeInSeconds source, but validity
+        // filtering can drop different samples from each, so pair by timestamp
+        // intersection instead of by index.
+        protected static IList<Tuple<Point, Point>> GetAlignedFinitePoints(
+            IList<Point> fpsPoints, IList<Point> gpuActiveFpsPoints)
+        {
+            var alignedPoints = new List<Tuple<Point, Point>>();
+            if (fpsPoints == null || gpuActiveFpsPoints == null)
+                return alignedPoints;
+
+            int fpsIndex = 0;
+            int gpuIndex = 0;
+            while (fpsIndex < fpsPoints.Count && gpuIndex < gpuActiveFpsPoints.Count)
+            {
+                Point fpsPoint = fpsPoints[fpsIndex];
+                Point gpuPoint = gpuActiveFpsPoints[gpuIndex];
+                if (fpsPoint.X < gpuPoint.X)
+                {
+                    fpsIndex++;
+                    continue;
+                }
+                if (gpuPoint.X < fpsPoint.X)
+                {
+                    gpuIndex++;
+                    continue;
+                }
+
+                if (IsFinite(fpsPoint.Y) && IsFinite(gpuPoint.Y))
+                    alignedPoints.Add(Tuple.Create(fpsPoint, gpuPoint));
+                fpsIndex++;
+                gpuIndex++;
+            }
+
+            return alignedPoints;
+        }
+
+        private static bool IsFinite(double value)
+        {
+            return !double.IsNaN(value) && !double.IsInfinity(value);
         }
     }
 

--- a/source/CapFrameX.ViewModel/ReportViewModel.cs
+++ b/source/CapFrameX.ViewModel/ReportViewModel.cs
@@ -305,9 +305,14 @@ namespace CapFrameX.ViewModel
                 sequence.Any()
                     ? Math.Round(sequence.Average(), _appConfiguration.FpsValuesRoundingDigits, MidpointRounding.AwayFromZero)
                     : double.NaN;
-            var frameTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents).ToList();
-            var displayTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange).ToList();
-            var samples = _appConfiguration.UseDisplayChangeMetrics ? displayTimes : frameTimes;
+            var frameTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenPresents)
+                .Where(time => time > 0 && !double.IsNaN(time) && !double.IsInfinity(time))
+                .ToList();
+            var displayTimes = session.Runs.SelectMany(r => r.CaptureData.MsBetweenDisplayChange)
+                .Where(time => time > 0 && !double.IsNaN(time) && !double.IsInfinity(time))
+                .ToList();
+            var samples = _appConfiguration.UseDisplayChangeMetrics && displayTimes.Any()
+                ? displayTimes : frameTimes;
 
             var GpuActiveTimes = session.Runs.SelectMany(r => r.CaptureData.GpuActive).ToList();
             var animationErrorsAbs = session.Runs


### PR DESCRIPTION
## Summary

This extracts the statistics-correctness work from #398 into a focused change, following the review request.

It fixes invalid timing handling, outlier boundaries, variance classification, timing-source consistency, and related depiction/export behavior without including the separate statistics-performance work.

## Statistics correctness

- Reject non-finite, zero, and negative frametime/display samples before analysis.
- Preserve valid zero values for GPU/CPU active timing while rejecting negative/non-finite values.
- Apply outlier removal after time-window selection and preserve the original timestamps of surviving points.
- Remove exactly the slowest 0.1% for deci-percentile filtering, including the exact 1,000-sample boundary.
- Preserve constant sequences and handle duplicate cutoff values by count.
- Return the unchanged sequence for unsupported outlier modes instead of `null`.
- Make variance bins mutually exclusive, ignore non-finite adjacent pairs, and return finite zeroes when no pairs exist.
- Preserve multi-run boundaries so comparison variance never introduces an artificial pair between captures.

## Timing-source consistency and depiction

- Use display-change timing only when every compared session/run supports valid present and display timing; otherwise all records use present timing.
- Keep Average FPS present-based.
- Apply the resolved source consistently to low metrics, line/FPS/distribution/L-shape/variance charts, sorting, and labels.
- Add an explicit timing-source label in the comparison UI.
- Filter report and online timing metrics consistently and fall back to present timing when display samples are unavailable.
- Align GPU-active clipboard export by timestamp intersection and exclude non-finite pairs.
- Use separate scratch storage/locks for realtime and five-second online calculations and cleanup.

## Deliberately excluded

- Batch metric APIs and sorted-sequence caching.
- Sparse distribution performance.
- Record parsing/loading and persistence.
- WPF background loading, virtualization, and OxyPlot decimation.
- Build tooling and dependency changes.

## Regression coverage

Tests cover invalid timing, active-time zeroes, timestamp-preserving outliers, exact percentile boundaries, constant/duplicate sequences, unsupported modes, variance bins, multi-run boundaries, display distribution source, comparison source fallback, and aligned clipboard data.

## Validation

- x64 Release application build: passed, 0 errors.
- x64 Release test build: passed, 0 errors.
- Focused frametime-statistics tests: 37/37 passed after the final review fixes.
- Full suite: 270 total, 265 passed, 5 hardware-dependent skips, 0 failed.
- `git diff --check`: passed.
- No package/dependency changes.

This PR is based directly on `v1.8.6` (`383bc029`). The clean statistics-performance delta is staged at fpsheaven/CapFrameX#1 and will be submitted upstream after this foundation lands.
